### PR TITLE
Use latest paho-mqtt version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from pyworxcloud import __version__
 import setuptools
 
-requirements = ['paho-mqtt==1.3.1',
+requirements = ['paho-mqtt==1.5.0',
                 'pyOpenSSL==17.5.0']
 
 setuptools.setup(


### PR DESCRIPTION
Home Assistant has issues when there is a lower version of paho-mqtt: https://github.com/home-assistant/core/issues/38007