### PR TITLE
Add 's' attribute (rain event in progress / rain sensor wet)

### DIFF
--- a/pyworxcloud/__init__.py
+++ b/pyworxcloud/__init__.py
@@ -216,6 +216,9 @@ class WorxCloud:
                     self.gps_longitude = data["dat"]["modules"]["4G"]["gps"]["coo"][1]
             if "rain" in data["dat"]:
                 self.rain_delay_time_remaining = data["dat"]["rain"]["cnt"]
+                self.rain_sensor_triggered = (
+                    True if str(data["dat"]["rain"]["s"]) == "1" else False
+                )
 
         if "cfg" in data:
             self.updated = data["cfg"]["tm"] + " " + data["cfg"]["dt"]


### PR DESCRIPTION
Related to my previous pull request.

I didn't think this mattered with my previous PR, but because we are only polling the cloud every 10 minutes we don't see the rain delay countdown in real time. I was comparing the rain delay countdown to the last mqtt update, but of course the robot doesn't start the countdown until the sensor is dry. Meaning my template in home assistant would start counting down, but would then reset when fresh data arrived.

Adding the rain_sensor_triggered attribute allows me to not start the countdown until the state is false.

### adds attributes:
    rain_sensor_triggered

### relevant section of the json:
Sensor wet
```json
	"dat": {

		"rain": {
			"s": 1,
			"cnt": 120,
                },
```
Sensor dry (118 minutes remaining)
```json
	"dat": {

		"rain": {
			"s": 0,
			"cnt": 118,
                },
```