### PR TITLE
Removing unused update function

### DIFF
--- a/pyworxcloud/__init__.py
+++ b/pyworxcloud/__init__.py
@@ -389,20 +389,20 @@ class WorxCloud:
         for attr, val in products[self._dev_id].items():
             setattr(self, str(attr), val)
 
-    def update(self) -> None:
-        """Update device states."""
-        self.wait = True
+    # def update(self) -> None:
+    #     """Update device states."""
+    #     self.wait = True
 
-        self._fetch()
-        if self.online:
-            request_time = int(time.time())
-            self._mqtt.publish(self.mqtt_in, "{}", qos=0, retain=False)
-            while self.wait:
-                if (request_time + MAX_WAIT) > int(time.time()):
-                    time.sleep(0.5)
-                else:
-                    self.wait = False
-                    raise TimeoutError("Connection timed out") from None
+    #     self._fetch()
+    #     if self.online:
+    #         request_time = int(time.time())
+    #         self._mqtt.publish(self.mqtt_in, "{}", qos=0, retain=False)
+    #         while self.wait:
+    #             if (request_time + MAX_WAIT) > int(time.time()):
+    #                 time.sleep(0.5)
+    #             else:
+    #                 self.wait = False
+    #                 raise TimeoutError("Connection timed out") from None
 
     def enumerate(self) -> int:
         """Enumerate amount of devices attached to account."""

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="pyworxcloud",
-    version="1.4.18",
+    version="1.4.19",
     description="Worx Landroid API library",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Update function no longer used.
Use getstatus instead, to prevent bans from calling too often.