### PR TITLE
Add support for wheel torque attribute

### DIFF
--- a/pyworxcloud/__init__.py
+++ b/pyworxcloud/__init__.py
@@ -88,6 +88,7 @@ class WorxCloud:
         self.serial_number = None
         self.status = None
         self.status_description = None
+        self.torque = None
         self.updated = None
         self.work_time = 0
         self.yaw = 0
@@ -255,6 +256,10 @@ class WorxCloud:
             self.updated = data["cfg"]["tm"] + " " + data["cfg"]["dt"]
             self.rain_delay = data["cfg"]["rd"]
             self.serial = data["cfg"]["sn"]
+
+            # Fetch wheel torque
+            if "tq" in data["cfg"]:
+                self.torque = data["cfg"]["tq"]
 
             # Fetch zone information
             if "mz" in data["cfg"]:


### PR DESCRIPTION
The wheel torque of landroid robots can be adjusted since firmware version 3.26 by setting an offset attribute. The current state of the relevant attribute `cfg.tq` is only included in mqtt updates. The `cfg.tq` attribute is writable and can be adjusted from -50 to +50 in percent, with 0 being the default torque.

JSON:
```
"cfg": {
    "tq": -10
}
```