### PR TITLE
forward of initial status data from REST API to MQTT

### DIFF
--- a/pyworxcloud/__init__.py
+++ b/pyworxcloud/__init__.py
@@ -502,10 +502,14 @@ class WorxCloud(dict):
 
         for mower in self._mowers:
             device = DeviceHandler(self._api, mower)
+            device.raw_data = json.dumps(mower["last_status"]["payload"])
             _LOGGER.debug("Mower '%s' data: %s", mower["name"], mower)
             self.devices.update({mower["name"]: device})
 
             self._decode_data(device)
+            self._events.call(
+                LandroidEvent.DATA_RECEIVED, name=mower["name"], device=device
+            )
 
     def get_mower(self, serial_number: str) -> dict:
         """Get a specific mower."""


### PR DESCRIPTION
When the module is restarted no information is available until the first MQTT message arrives from the robot. This update should fix the problem by filling data with initial infos received from authentication/status API