### PR TITLE
Identify using MAC address if serial not present

### DIFF
--- a/pyworxcloud/__init__.py
+++ b/pyworxcloud/__init__.py
@@ -279,9 +279,17 @@ class WorxCloud(dict):
         logger.debug("MQTT data received")
         # logger.debug("MQTT data received '%s' on topic '%s'", payload, topic)
 
+        # "Malformed" message, we are missing a serial number to identify the mower.
+        if not "sn" in data["cfg"] and not "mac" in data["dat"]:
+            return
+
         for mower in self._mowers:
-            if mower["serial_number"] == data["cfg"]["sn"]:
-                break
+            if "sn" in data["cfg"]:
+                if mower["serial_number"] == data["cfg"]["sn"]:
+                    break
+            else:
+                if mower["mac_address"] == data["dat"]["mac"]:
+                    break
 
         device: DeviceHandler = self.devices[mower["name"]]
 

--- a/test.py
+++ b/test.py
@@ -18,8 +18,6 @@ cloud = WorxCloud(EMAIL, PASS, TYPE)
 cloud.authenticate()
 cloud.connect()
 
-cloud.setzone("20213028401100013915", 2)
-
 # print(vars(cloud))
 
 cloud.disconnect()


### PR DESCRIPTION
Do matching of device using MAC address if serial number wasn't present in the MQTT data.

If neither MAC or serial number was present in the MQTT payload, then ditch the message as malformed.