### PR TITLE
Fixing race on zone with no probability

### DIFF
--- a/pyworxcloud/__init__.py
+++ b/pyworxcloud/__init__.py
@@ -17,7 +17,8 @@ from .exceptions import (
     NoOneTimeScheduleError,
     NoPartymodeError,
     OfflineError,
-    RequestException,
+    ZoneNoProbability,
+    ZoneNotDefined,
 )
 from .helpers import convert_to_time, get_logger
 from .utils import (
@@ -691,7 +692,12 @@ class WorxCloud(dict):
                 zone = int(zone)
 
             if device.zone["starting_point"][zone] == 0:
-                raise RequestException("Cannot request this zone as it is not defined.")
+                raise ZoneNotDefined("Cannot request this zone as it is not defined.")
+
+            if not zone in device.zone["indicies"]:
+                raise ZoneNoProbability(
+                    "Cannot request this zone as it has no probability set."
+                )
 
             current = device.zone["indicies"]
             new_zones = current

--- a/pyworxcloud/exceptions.py
+++ b/pyworxcloud/exceptions.py
@@ -82,3 +82,10 @@ class MowerNotFoundError(Exception):
 
 class NoConnectionError(Exception):
     """Raised when the endpoint cannot be reached."""
+
+class ZoneNotDefined(Exception):
+    """Raised when the requested zone is not defined."""
+
+class ZoneNoProbability(Exception):
+    """Raised when the requested zone is has no probability set."""
+


### PR DESCRIPTION
Fixing race condition when no probability was set for requested zone.
Also introduced 2 new exceptions:

ZoneNotDefined: Raised when the requested zone has not been defined (no starting point)

ZoneNoProbability: Raised when the requested zone has no pobability set