### PR TITLE
Check if mowers are available

### DIFF
--- a/pyworxcloud/__init__.py
+++ b/pyworxcloud/__init__.py
@@ -234,6 +234,10 @@ class WorxCloud(dict):
         self._log.debug("Fetching basic API data")
         self._fetch()
         self._log.debug("Done fetching basic API data")
+        
+        if len(self._mowers) == 0:
+            self._log.debug("no mowers connected to account")
+            return false
 
         self._endpoint = self._mowers[0]["mqtt_endpoint"]
         self._user_id = self._mowers[0]["user_id"]

--- a/pyworxcloud/__init__.py
+++ b/pyworxcloud/__init__.py
@@ -237,7 +237,7 @@ class WorxCloud(dict):
         
         if len(self._mowers) == 0:
             self._log.debug("no mowers connected to account")
-            return false
+            return False
 
         self._endpoint = self._mowers[0]["mqtt_endpoint"]
         self._user_id = self._mowers[0]["user_id"]


### PR DESCRIPTION
When a new account is setup but has no mower added yet an exception can occur.

Fixes

```
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/config_entries.py", line 387, in async_setup
    result = await component.async_setup_entry(hass, self)
  File "/config/custom_components/landroid_cloud/__init__.py", line 63, in async_setup_entry
    result = await _async_setup(hass, entry)
  File "/config/custom_components/landroid_cloud/__init__.py", line 206, in _async_setup
    await hass.async_add_executor_job(cloud.connect)
  File "/usr/local/lib/python3.10/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/usr/local/lib/python3.10/site-packages/pyworxcloud/__init__.py", line 238, in connect
    self._endpoint = self._mowers[0]["mqtt_endpoint"]
IndexError: list index out of range
```