### PR TITLE
Add forced refresh scheduling

### DIFF
--- a/pyworxcloud/__init__.py
+++ b/pyworxcloud/__init__.py
@@ -259,7 +259,6 @@ class WorxCloud(dict):
         self._log.debug("MQTT connect done")
 
         # Convert time strings to objects.
-        self._log.debug("Converting date and time string")
         for name, device in self.devices.items():
             convert_to_time(
                 name, device, device.time_zone, callback=self.update_attribute


### PR DESCRIPTION
Some models doesn't update automatically very often.
As a measure to combat this and get more real-time-like data, a forced refresh will be sent approx. 15 minutes after last data was received.
The scheduler are reset whenever data was received, also when data is automatically sent from the device - this to prevent possibly banning for too many requests.