### PR TITLE
handle disconnect when no mower in account

### DIFF
--- a/pyworxcloud/__init__.py
+++ b/pyworxcloud/__init__.py
@@ -223,7 +223,8 @@ class WorxCloud(dict):
 
     def disconnect(self) -> None:
         """Close API connections."""
-        self.mqtt.disconnect()
+        if self.mqtt:
+            self.mqtt.disconnect()
 
     def connect(
         self,


### PR DESCRIPTION
When there is no mower in the account (previous patch #158) there is no mqtt connection so self.mqtt is None and we can not call .disconnect()

This patch is required to reload the homeassistant integration and not get a exception