### PR TITLE
Fix Schedule for Landroid Vision

### DIFF
--- a/pyworxcloud/__init__.py
+++ b/pyworxcloud/__init__.py
@@ -520,7 +520,8 @@ class WorxCloud(dict):
                         if not is_vision
                         else len(data["cfg"]["sc"]["slots"]),
                     ):
-                        device.schedules[TYPE_TO_STRING[sch_type]][DAY_MAP[day]][
+                        dayOfWeek = day if not is_vision else data["cfg"]["sc"]["slots"][day]["d"]
+                        device.schedules[TYPE_TO_STRING[sch_type]][DAY_MAP[dayOfWeek]][
                             "start"
                         ] = (
                             data["cfg"]["sc"]["d"][day][0]
@@ -532,14 +533,14 @@ class WorxCloud(dict):
                                 )
                             ).strftime("%H:%M")
                         )
-                        device.schedules[TYPE_TO_STRING[sch_type]][DAY_MAP[day]][
+                        device.schedules[TYPE_TO_STRING[sch_type]][DAY_MAP[dayOfWeek]][
                             "duration"
                         ] = (
                             data["cfg"]["sc"]["d"][day][1]
                             if not is_vision
                             else data["cfg"]["sc"]["slots"][day]["t"]
                         )
-                        device.schedules[TYPE_TO_STRING[sch_type]][DAY_MAP[day]][
+                        device.schedules[TYPE_TO_STRING[sch_type]][DAY_MAP[dayOfWeek]][
                             "boundary"
                         ] = (
                             bool(data["cfg"]["sc"]["d"][day][2])
@@ -550,24 +551,24 @@ class WorxCloud(dict):
                         )
 
                         time_start = datetime.strptime(
-                            device.schedules[TYPE_TO_STRING[sch_type]][DAY_MAP[day]][
+                            device.schedules[TYPE_TO_STRING[sch_type]][DAY_MAP[dayOfWeek]][
                                 "start"
                             ],
                             "%H:%M",
                         )
 
                         if isinstance(
-                            device.schedules[TYPE_TO_STRING[sch_type]][DAY_MAP[day]][
+                            device.schedules[TYPE_TO_STRING[sch_type]][DAY_MAP[dayOfWeek]][
                                 "duration"
                             ],
                             type(None),
                         ):
-                            device.schedules[TYPE_TO_STRING[sch_type]][DAY_MAP[day]][
+                            device.schedules[TYPE_TO_STRING[sch_type]][DAY_MAP[dayOfWeek]][
                                 "duration"
                             ] = "0"
 
                         duration = int(
-                            device.schedules[TYPE_TO_STRING[sch_type]][DAY_MAP[day]][
+                            device.schedules[TYPE_TO_STRING[sch_type]][DAY_MAP[dayOfWeek]][
                                 "duration"
                             ]
                         )
@@ -577,7 +578,7 @@ class WorxCloud(dict):
                         )
                         end_time = time_start + timedelta(minutes=duration)
 
-                        device.schedules[TYPE_TO_STRING[sch_type]][DAY_MAP[day]][
+                        device.schedules[TYPE_TO_STRING[sch_type]][DAY_MAP[dayOfWeek]][
                             "end"
                         ] = end_time.time().strftime("%H:%M")
 


### PR DESCRIPTION
The current implementation fails to detect my Landroid.

Docker logs show the error
```
Traceback (most recent call last):                                                                                                                                                             
  File "/usr/local/lib/python3.11/site-packages/pyworxcloud/__init__.py", line 524, in _decode_data                                                                                            
    device.schedules[TYPE_TO_STRING[sch_type]][DAY_MAP[day]][                                                                                                                                  
                                               ~~~~~~~^^^^^        
```

I observed the decoded data and noticed that `data.cfg.sc.slots` contains more than 6 items.
Each entry is not a day, but a schedule (I have several schedules per day)
The day number is located in the property `d` of the item.

Bellow an extract of the decoded data

<details><summary>Show the payload</summary>

```json
{
  "cfg": {
    "sc": {
      "slots": [
        {
          "e": 1,
          "d": 0,
          "s": 660,
          "t": 135,
          "cfg": {
            "cut": {
              "b": 1,
              "z": []
            }
          }
        },
        {
          "e": 1,
          "d": 0,
          "s": 1080,
          "t": 135,
          "cfg": {
            "cut": {
              "b": 0,
              "z": []
            }
          }
        },
        {
          "e": 1,
          "d": 1,
          "s": 660,
          "t": 135,
          "cfg": {
            "cut": {
              "b": 0,
              "z": []
            }
          }
        },
        {
          "e": 1,
          "d": 1,
          "s": 1080,
          "t": 135,
          "cfg": {
            "cut": {
              "b": 0,
              "z": []
            }
          }
        },
        {
          "e": 1,
          "d": 2,
          "s": 660,
          "t": 135,
          "cfg": {
            "cut": {
              "b": 0,
              "z": []
            }
          }
        },
        {
          "e": 1,
          "d": 2,
          "s": 1080,
          "t": 135,
          "cfg": {
            "cut": {
              "b": 0,
              "z": []
            }
          }
        },
        {
          "e": 1,
          "d": 3,
          "s": 660,
          "t": 135,
          "cfg": {
            "cut": {
              "b": 1,
              "z": []
            }
          }
        },
        {
          "e": 1,
          "d": 3,
          "s": 1080,
          "t": 135,
          "cfg": {
            "cut": {
              "b": 0,
              "z": []
            }
          }
        },
        {
          "e": 1,
          "d": 4,
          "s": 660,
          "t": 135,
          "cfg": {
            "cut": {
              "b": 0,
              "z": []
            }
          }
        },
        {
          "e": 1,
          "d": 4,
          "s": 1080,
          "t": 135,
          "cfg": {
            "cut": {
              "b": 0,
              "z": []
            }
          }
        },
        {
          "e": 1,
          "d": 5,
          "s": 660,
          "t": 135,
          "cfg": {
            "cut": {
              "b": 0,
              "z": []
            }
          }
        },
        {
          "e": 1,
          "d": 5,
          "s": 1080,
          "t": 135,
          "cfg": {
            "cut": {
              "b": 0,
              "z": []
            }
          }
        },
        {
          "e": 1,
          "d": 6,
          "s": 660,
          "t": 135,
          "cfg": {
            "cut": {
              "b": 0,
              "z": []
            }
          }
        },
        {
          "e": 1,
          "d": 6,
          "s": 1080,
          "t": 135,
          "cfg": {
            "cut": {
              "b": 0,
              "z": []
            }
          }
        }
      ]
    }
  }
}
```

</details>
