### PR TITLE
Fix missing gps key in early startup phase

### DIFF
--- a/pyworxcloud/__init__.py
+++ b/pyworxcloud/__init__.py
@@ -465,10 +465,13 @@ class WorxCloud(dict):
                 # Check for extra module availability
                 if "modules" in data["dat"]:
                     if "4G" in data["dat"]["modules"]:
-                        device.gps = Location(
-                            data["dat"]["modules"]["4G"]["gps"]["coo"][0],
-                            data["dat"]["modules"]["4G"]["gps"]["coo"][1],
-                        )
+                        if data["dat"]["modules"]['4G']['geo']['stat'] == 'unk':
+                          logger.warn("dat.modules.4G.geo.stat is unknown")
+                        else:
+                            device.gps = Location(
+                               data["dat"]["modules"]["4G"]["gps"]["coo"][0],
+                               data["dat"]["modules"]["4G"]["gps"]["coo"][1],
+                            )
 
                 # Get remaining rain delay if available
                 if "rain" in data["dat"]:


### PR DESCRIPTION
While startup the gps coordinates might not be available. Accessing them will lead to

KeyError gps

this patch prevents from accessing dat.modules.4G.gps if geo.stat is unknown.
