### PR TITLE
Increase forced refresh time to 60 minutes

### DIFF
--- a/pyworxcloud/__init__.py
+++ b/pyworxcloud/__init__.py
@@ -40,7 +40,7 @@ if sys.version_info < (3, 9, 0):
 
 _LOGGER = logging.getLogger(__name__)
 
-REFRESH_TIME = 30
+REFRESH_TIME = 60
 API_REFRESH_TIME = 15
 
 

--- a/pyworxcloud/__init__.py
+++ b/pyworxcloud/__init__.py
@@ -40,7 +40,8 @@ if sys.version_info < (3, 9, 0):
 
 _LOGGER = logging.getLogger(__name__)
 
-REFRESH_TIME = 5
+REFRESH_TIME = 30
+API_REFRESH_TIME = 15
 
 
 class WorxCloud(dict):
@@ -426,13 +427,15 @@ class WorxCloud(dict):
                 pass
 
         logger = self._log.getChild("API_Refresh_Scheduler")
-        next_api_refresh = datetime.now() + timedelta(minutes=REFRESH_TIME)
+        next_api_refresh = datetime.now() + timedelta(minutes=API_REFRESH_TIME)
         logger.debug(
             "Scheduling an API refresh at %s",
             next_api_refresh,
         )
 
-        force_api_refresh = threading.Timer(REFRESH_TIME * 60, self._fetch, args=[True])
+        force_api_refresh = threading.Timer(
+            API_REFRESH_TIME * 60, self._fetch, args=[True]
+        )
         force_api_refresh.start()
         self._timers.update({"api": force_api_refresh})
 


### PR DESCRIPTION
To circumvent bans.

The mower automatically updates whenever there is anything to update, or every 10 minutes  regardless of changes.

Normally no need to force an refresh anymore, so setting forced refresh to 60 minutes for now - perhaps fully removing the forced refresh in the future.