### PR TITLE
Change state description

### DIFF
--- a/pyworxcloud/utils/state.py
+++ b/pyworxcloud/utils/state.py
@@ -17,7 +17,7 @@ STATE_TO_DESCRIPTION = {
     5: "searching home",
     6: "searching wire",
     7: "mowing",
-    8: "lifted",
+    8: "mowing",
     9: "trapped",
     10: "blade blocked",
     11: "debug",


### PR DESCRIPTION
Sometimes when mower tries to fix a "lifted" error, it goes to state lifted but doesn't generate an error - this tries to fix this and still mark the mower as mowing until an error is cast