### PR TITLE
Harden HTTP retries and reduce product lookup API calls

### DIFF
--- a/pyworxcloud/api.py
+++ b/pyworxcloud/api.py
@@ -39,6 +39,7 @@ class LandroidCloudAPI:
         self.uuid = None
         self._api_host = None
         self.api_data = None
+        self._products_cache = None
         self._tz = tz
         self._callback = token_callback
 
@@ -124,13 +125,24 @@ class LandroidCloudAPI:
             f"https://{self.cloud.ENDPOINT}/api/v2/product-items?status=1",
             HEADERS(self.access_token),
         )
+        products = self._get_products()
+        product_map = {item["id"]: item for item in products}
+
         for mower in mowers:
             if mower["name"] is None:
                 # Add default name when mower is unnamed
                 mower["name"] = "No Name"
 
             _LOGGER.debug("Matching models for mower '%s'", mower["name"])
-            model = self.get_model(mower["product_id"])
+            model = product_map.get(mower["product_id"])
+            if model is None:
+                _LOGGER.debug(
+                    "Could not match model for mower '%s' (product_id=%s)",
+                    mower["name"],
+                    mower["product_id"],
+                )
+                continue
+
             mower["model"] = {
                 "code": model["code"],
                 "friendly_name": str.format(
@@ -151,10 +163,7 @@ class LandroidCloudAPI:
         """
         self.check_token()
 
-        products = GET(
-            f"https://{self.cloud.ENDPOINT}/api/v2/products",
-            HEADERS(self.access_token),
-        )
+        products = self._get_products()
 
         product_info = None
         for product in products:
@@ -163,6 +172,17 @@ class LandroidCloudAPI:
                 break
 
         return product_info
+
+    def _get_products(self) -> list:
+        """Get product list from cache or API."""
+        self.check_token()
+        if self._products_cache is None:
+            self._products_cache = GET(
+                f"https://{self.cloud.ENDPOINT}/api/v2/products",
+                HEADERS(self.access_token),
+            )
+
+        return self._products_cache
 
     @property
     def data(self) -> str:

--- a/pyworxcloud/utils/requests.py
+++ b/pyworxcloud/utils/requests.py
@@ -28,9 +28,14 @@ BACKOFF_FACTOR = 3
 
 def backoff(retry: int) -> float:
     """Calculate backoff time."""
-    val: float = BACKOFF_FACTOR * (2 ** (retry - 1))
+    val: float = BACKOFF_FACTOR * (2**retry)
 
     return val if val <= MAX_BACKOFF else MAX_BACKOFF
+
+
+def _is_last_retry(retry: int) -> bool:
+    """Return true if this is the last retry attempt."""
+    return retry >= (NUM_RETRIES - 1)
 
 
 def HEADERS(access_token: str | None = None) -> dict:
@@ -79,14 +84,21 @@ def POST(URL: str, REQUEST_BODY: str, HEADER: dict | None = None) -> str:
             elif code == 503:
                 raise ServiceUnavailableError()
             elif code == 504:
+                if _is_last_retry(retry):
+                    break
                 sleep(backoff(retry))
                 continue
             else:
                 raise APIError(err)
-        except requests.exceptions.ConnectionError:
-            raise TooManyRequestsError()
-        except urllib3.exceptions.MaxRetryError:
-            raise TooManyRequestsError()
+        except (
+            requests.exceptions.ConnectionError,
+            requests.exceptions.Timeout,
+            urllib3.exceptions.MaxRetryError,
+        ):
+            if _is_last_retry(retry):
+                break
+            sleep(backoff(retry))
+            continue
     raise NoConnectionError()
 
 
@@ -121,9 +133,20 @@ def GET(URL: str, HEADER: dict | None = None) -> str:
             elif code == 503:
                 raise ServiceUnavailableError()
             elif code == 504:
+                if _is_last_retry(retry):
+                    break
                 sleep(backoff(retry))
-                pass
+                continue
             else:
                 raise APIError(err)
+        except (
+            requests.exceptions.ConnectionError,
+            requests.exceptions.Timeout,
+            urllib3.exceptions.MaxRetryError,
+        ):
+            if _is_last_retry(retry):
+                break
+            sleep(backoff(retry))
+            continue
 
     raise NoConnectionError()


### PR DESCRIPTION
## Summary
Improves HTTP reliability under transient network failures and reduces API pressure by removing repeated product catalog lookups.

## Changes
- Reworked retry behavior for GET/POST to treat connection and timeout failures as transient transport failures with backoff.
- Ensured final transport failure maps to `NoConnectionError` instead of `TooManyRequestsError` for non-429 conditions.
- Fixed GET retry flow to continue correctly on 504.
- Updated backoff progression and last-retry handling.
- Added in-memory product cache and map-based product lookup to avoid N+1 `/products` calls when listing mowers.

## Testing
- `python3 -m compileall -q pyworxcloud`

## Notes
- Repository currently uses `master` as default branch; PR is opened against `master`.