### PR TITLE
Add changelog and migration guide for hardening releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on Keep a Changelog and this project follows Semantic Versioning.
+
+## [Unreleased]
+
+### Changed
+- Stabilized connector lifecycle so disconnect stops scheduled API refresh work.
+- Hardened HTTP transport retry behavior for connection and timeout failures.
+- Reduced API pressure by avoiding repeated product catalog lookups during mower listing.
+- Enforced serialized MQTT command handling: a new command is blocked until the prior command is acknowledged or times out.
+
+### Fixed
+- Removed silent token retrieval failure masking in authentication flow.
+- Fixed MQTT command flow that previously could continue without bounded response handling.
+
+### Notes
+- This section currently reflects merged refactor hardening PRs: `#294`, `#295`, `#296`.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,61 @@
+# Migration Guide
+
+This guide covers behavior and integration changes introduced by the refactor hardening series.
+
+## Scope
+
+The changes in this guide are based on merged hardening pull requests:
+
+- `#294` lifecycle/disconnect stabilization
+- `#295` HTTP transport hardening
+- `#296` MQTT command serialization + timeout enforcement
+
+## Breaking Behavior Changes
+
+### 1. MQTT commands are now serialized
+
+Only one command can be in flight per MQTT client at a time.
+
+What this means for integrations:
+
+- Do not assume fire-and-forget behavior.
+- Queue commands on your side if you trigger multiple actions quickly.
+- Expect the next command to wait until prior command response or timeout.
+
+### 2. Command response timeout is now enforced
+
+MQTT command send now has bounded wait behavior and raises timeout errors when no matching response is received in time.
+
+What this means for integrations:
+
+- Handle `TimeoutException` explicitly.
+- Surface timeout errors in UI/automation logic as retryable failures.
+- Avoid infinite waiting states in calling code.
+
+### 3. Transport-level failures are no longer misclassified
+
+Connection and timeout failures in HTTP transport now map to connection-style failures after retries, not rate-limit errors.
+
+What this means for integrations:
+
+- Treat `NoConnectionError` as network/transient endpoint availability failure.
+- Keep `TooManyRequestsError` handling for actual quota/rate-limit cases.
+
+### 4. Disconnect semantics are stricter
+
+Calling `disconnect()` now reliably blocks new refresh scheduling and cancels timers.
+
+What this means for integrations:
+
+- You can rely on disconnect to stop background API refresh loops.
+- Reconnect paths should call `connect()` explicitly to re-enable background refresh.
+
+## Recommended Integration Updates
+
+1. Add explicit timeout handling around command dispatch.
+2. Centralize retry policy in your integration layer for `NoConnectionError`.
+3. Ensure your command API is queue-based or lock-protected.
+4. Update user-facing error texts to distinguish:
+   - rate-limited
+   - offline/no connection
+   - command timed out

--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ The module are compatible with cloud enabled devices from [these vendors](https:
 ## Documentation
 
 The documentation have been moved to the [Wiki](https://github.com/MTrab/pyworxcloud/wiki)<br/>
+Additional project docs:
+
+- [Migration Guide](./MIGRATION.md)
+- [Changelog](./CHANGELOG.md)
 
 ## Testing
 


### PR DESCRIPTION
## Summary
Adds baseline release documentation for the merged hardening work, including migration guidance for integrators and a maintained changelog structure.

## Changes
- Added `CHANGELOG.md` with an `Unreleased` section for merged hardening changes.
- Added `MIGRATION.md` describing integration-impacting behavior changes (disconnect lifecycle, HTTP error mapping, command serialization, timeout handling).
- Updated `README.md` with links to `MIGRATION.md` and `CHANGELOG.md`.

## Testing
- Documentation-only change (no runtime code changes).

## Notes
- Migration guide content is based on merged hardening PRs `#294`, `#295`, and `#296`.
- Repository currently uses `master` as default branch; PR is opened against `master`.