### PR TITLE
Isolate EventHandler callbacks per instance

### DIFF
--- a/pyworxcloud/events.py
+++ b/pyworxcloud/events.py
@@ -44,10 +44,9 @@ def check_syntax(args: dict[str, Any], objs: list[str], expected_type: Any) -> b
 class EventHandler:
     """Event handler for Landroid Cloud."""
 
-    __events: dict[LandroidEvent, Any] = {}
-
     def __init__(self) -> None:
         """Initialize the event handler object."""
+        self.__events: dict[LandroidEvent, Any] = {}
 
     def set_handler(self, event: LandroidEvent, func: Any) -> None:
         """Set handler for a LandroidEvent"""
@@ -55,7 +54,7 @@ class EventHandler:
 
     def del_handler(self, event: LandroidEvent) -> None:
         """Remove a handler for a LandroidEvent."""
-        self.__events.pop(event)
+        self.__events.pop(event, None)
 
     def call(self, event: LandroidEvent, **kwargs) -> bool:
         """Call a handler if it was set."""

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,0 +1,38 @@
+"""Tests for event handler isolation and callback behavior."""
+
+from __future__ import annotations
+
+from pyworxcloud.events import EventHandler, LandroidEvent
+
+
+def test_event_handlers_are_isolated_per_instance() -> None:
+    """Each EventHandler instance should keep its own callbacks."""
+    first = EventHandler()
+    second = EventHandler()
+
+    calls: list[str] = []
+
+    first.set_handler(
+        LandroidEvent.MQTT_CONNECTION,
+        lambda state: calls.append(f"first:{state}"),
+    )
+    second.set_handler(
+        LandroidEvent.MQTT_CONNECTION,
+        lambda state: calls.append(f"second:{state}"),
+    )
+
+    assert first.call(LandroidEvent.MQTT_CONNECTION, state=True) is True
+    assert calls == ["first:True"]
+
+
+def test_deleting_handler_does_not_affect_other_instances() -> None:
+    """Removing a callback from one instance must not remove it from another."""
+    first = EventHandler()
+    second = EventHandler()
+
+    calls: list[bool] = []
+    second.set_handler(LandroidEvent.MQTT_CONNECTION, lambda state: calls.append(state))
+
+    first.del_handler(LandroidEvent.MQTT_CONNECTION)
+    assert second.call(LandroidEvent.MQTT_CONNECTION, state=False) is True
+    assert calls == [False]


### PR DESCRIPTION
## Summary
Isolate event callback storage per `EventHandler` instance to prevent callback leakage between parallel WorxCloud clients.

## Changes
- moved `EventHandler` callback map from class-level shared state to instance state initialized in `__init__`
- made `del_handler` idempotent (`pop(..., None)`) so cleanup is safe even when no callback is registered
- added `tests/test_events.py` with isolation-focused unit tests

## Testing
- `.venv/bin/pytest -q`

## Notes
- this is a behavior hardening change for multi-instance usage and refactor stability work