### PR TITLE
Reuse HTTP session in API request flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on Keep a Changelog and this project follows Semantic Versio
 - Stabilized connector lifecycle so disconnect stops scheduled API refresh work.
 - Hardened HTTP transport retry behavior for connection and timeout failures.
 - Reduced API pressure by avoiding repeated product catalog lookups during mower listing.
+- Reused HTTP sessions in API calls to improve connection pooling and request performance.
 - Enforced serialized MQTT command handling: a new command is blocked until the prior command is acknowledged or times out.
 - Added configurable MQTT command timeout via `WorxCloud(..., command_timeout=...)`.
 

--- a/pyworxcloud/api.py
+++ b/pyworxcloud/api.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 import logging
 import time
 
+import requests
+
 from .clouds import CloudType
 from .exceptions import TooManyRequestsError
 from .utils.requests import GET, HEADERS, POST
@@ -40,6 +42,7 @@ class LandroidCloudAPI:
         self._api_host = None
         self.api_data = None
         self._products_cache = None
+        self._session = requests.Session()
         self._tz = tz
         self._callback = token_callback
 
@@ -58,7 +61,7 @@ class LandroidCloudAPI:
         }
 
         try:
-            resp = POST(url, request_body, HEADERS())
+            resp = POST(url, request_body, HEADERS(), session=self._session)
             self.access_token = resp["access_token"]
             self.refresh_token = resp["refresh_token"]
             now = int(time.time())
@@ -76,7 +79,7 @@ class LandroidCloudAPI:
             "refresh_token": self.refresh_token,
         }
 
-        resp = POST(url, request_body, HEADERS())
+        resp = POST(url, request_body, HEADERS(), session=self._session)
         self.access_token = resp["access_token"]
         self.refresh_token = resp["refresh_token"]
         now = int(time.time())
@@ -122,6 +125,7 @@ class LandroidCloudAPI:
         mowers = GET(
             f"https://{self.cloud.ENDPOINT}/api/v2/product-items?status=1",
             HEADERS(self.access_token),
+            session=self._session,
         )
         products = self._get_products()
         product_map = {item["id"]: item for item in products}
@@ -178,6 +182,7 @@ class LandroidCloudAPI:
             self._products_cache = GET(
                 f"https://{self.cloud.ENDPOINT}/api/v2/products",
                 HEADERS(self.access_token),
+                session=self._session,
             )
 
         return self._products_cache

--- a/pyworxcloud/utils/requests.py
+++ b/pyworxcloud/utils/requests.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from time import sleep
+from typing import Any
 
 import requests
 import urllib3
@@ -52,7 +53,12 @@ def HEADERS(access_token: str | None = None) -> dict:
     return head
 
 
-def POST(URL: str, REQUEST_BODY: str, HEADER: dict | None = None) -> str:
+def POST(
+    URL: str,
+    REQUEST_BODY: str,
+    HEADER: dict | None = None,
+    session: Any | None = None,
+) -> str:
     """A request POST"""
 
     if isinstance(HEADER, type(None)):
@@ -60,7 +66,8 @@ def POST(URL: str, REQUEST_BODY: str, HEADER: dict | None = None) -> str:
 
     for retry in range(NUM_RETRIES):
         try:
-            req = requests.post(
+            client = session if session is not None else requests
+            req = client.post(
                 URL, REQUEST_BODY, headers=HEADER, timeout=60, cookies=None
             )  # 60 seconds timeout
 
@@ -102,14 +109,15 @@ def POST(URL: str, REQUEST_BODY: str, HEADER: dict | None = None) -> str:
     raise NoConnectionError()
 
 
-def GET(URL: str, HEADER: dict | None = None) -> str:
+def GET(URL: str, HEADER: dict | None = None, session: Any | None = None) -> str:
     """A request GET"""
     if isinstance(HEADER, type(None)):
         HEADER = HEADERS()
 
     for retry in range(NUM_RETRIES):
         try:
-            req = requests.get(
+            client = session if session is not None else requests
+            req = client.get(
                 URL, headers=HEADER, timeout=60, cookies=None
             )  # 60 seconds timeout
 

--- a/tests/test_api_lifecycle.py
+++ b/tests/test_api_lifecycle.py
@@ -87,9 +87,10 @@ def test_get_mowers_uses_products_cache(monkeypatch) -> None:
 
     calls = {"products": 0}
 
-    def _get(url: str, _headers: dict) -> list:
+    def _get(url: str, _headers: dict, session=None) -> list:
         if url.endswith("/api/v2/products"):
             calls["products"] += 1
+            assert session is not None
             return [
                 {
                     "id": 42,
@@ -119,6 +120,39 @@ def test_get_mowers_uses_products_cache(monkeypatch) -> None:
     assert first[0]["model"]["code"] == "WG123"
     assert second[0]["model"]["friendly_name"] == "Landroid500"
     assert calls["products"] == 1
+
+
+def test_get_mowers_passes_session_to_request_helper(monkeypatch) -> None:
+    """LandroidCloudAPI should reuse its HTTP session when calling GET helper."""
+    api = LandroidCloudAPI("user@example.com", "secret", CloudType.WORX)
+    api.access_token = "token"
+    api.refresh_token = "refresh"
+    api._token_expire = 9999999999
+
+    seen = {"session": None}
+
+    def _get(url: str, _headers: dict, session=None) -> list:
+        seen["session"] = session
+        if url.endswith("/api/v2/products"):
+            return [
+                {
+                    "id": 42,
+                    "code": "WG123",
+                    "default_name": "Landroid",
+                    "meters": "500",
+                    "product_year": 2024,
+                    "cutting_width": 18,
+                }
+            ]
+        if "product-items" in url:
+            return [{"name": "My Mower", "product_id": 42}]
+        raise AssertionError(f"Unexpected URL: {url}")
+
+    monkeypatch.setattr("pyworxcloud.api.GET", _get)
+
+    api.get_mowers()
+
+    assert seen["session"] is api._session
 
 
 def test_disconnect_cancels_timers_and_disconnects_mqtt() -> None:


### PR DESCRIPTION
## Summary
Reuse a single HTTP session in `LandroidCloudAPI` to improve connection pooling and reduce request overhead.

## Changes
- added an API-level `requests.Session()` stored on `LandroidCloudAPI`
- passed the shared session into request helper calls (`GET`/`POST`)
- extended request helper signatures to accept optional session clients while keeping backwards compatibility
- added a technical audit (`TECHNICAL-AUDIT.md`) that captures current risks, coverage and log points for follow-up
- updated lifecycle tests to validate session propagation to request helper
- updated changelog with HTTP session reuse entry

## Testing
- `.venv/bin/pytest -q`

## Notes
- Existing external call signatures remain compatible.
- Direct tests for `pyworxcloud.utils.requests` still work without supplying a session instance.
