### PR TITLE
Cleanup AWS CRT resources on MQTT disconnect

### DIFF
--- a/pyworxcloud/__init__.py
+++ b/pyworxcloud/__init__.py
@@ -252,8 +252,11 @@ class WorxCloud(dict):
         try:
             if self.mqtt is not None:
                 self.mqtt.disconnect()
+                self.mqtt.shutdown()
         except Exception as err:
             logger.debug("Could not disconnect MQTT cleanly: %s", err)
+        finally:
+            self.mqtt = None
 
     def connect(
         self,

--- a/pyworxcloud/utils/mqtt.py
+++ b/pyworxcloud/utils/mqtt.py
@@ -139,6 +139,7 @@ class MQTT(LDict):
         self._client_id = (
             f"{self._brandprefix}/USER/{self._user_id}/homeassistant/{self._uuid}"
         )
+        self._shutdown_event = False
 
         # Create event loop group and connection
         self._event_loop_group = awscrt.io.EventLoopGroup(1)
@@ -328,6 +329,34 @@ class MQTT(LDict):
             # Update state
             self._is_connected = False
             logger.debug("MQTT disconnected")
+
+    def shutdown(self) -> None:
+        """Release background AWS CRT resources."""
+        if not self._shutdown_event:
+            self._shutdown_event = True
+
+            # Force disconnect in case we're still connected.
+            if self.connected:
+                try:
+                    self.disconnect(keep_topic=True)
+                except Exception:  # pragma: no cover - defensive
+                    pass
+
+            self.client = None
+            host_resolver = self._host_resolver
+            client_bootstrap = self._client_bootstrap
+            event_loop_group = self._event_loop_group
+
+            self._host_resolver = None
+            self._client_bootstrap = None
+            self._event_loop_group = None
+
+            if host_resolver is not None and hasattr(host_resolver, "shutdown_event"):
+                host_resolver.shutdown_event.wait(5)
+            if client_bootstrap is not None and hasattr(client_bootstrap, "shutdown_event"):
+                client_bootstrap.shutdown_event.wait(5)
+            if event_loop_group is not None and hasattr(event_loop_group, "shutdown_event"):
+                event_loop_group.shutdown_event.wait(5)
 
     def ping(
         self,

--- a/tests/test_api_lifecycle.py
+++ b/tests/test_api_lifecycle.py
@@ -27,9 +27,13 @@ class DummyMQTT:
 
     def __init__(self) -> None:
         self.disconnect_called = False
+        self.shutdown_called = False
 
     def disconnect(self) -> None:
         self.disconnect_called = True
+
+    def shutdown(self) -> None:
+        self.shutdown_called = True
 
 
 class DummyDevice:
@@ -137,6 +141,8 @@ def test_disconnect_cancels_timers_and_disconnects_mqtt() -> None:
     assert cloud._timers == {}
     assert mqtt.disconnect_called is True
     assert cloud._disconnecting.is_set() is True
+    assert mqtt.shutdown_called is True
+    assert cloud.mqtt is None
 
 
 def test_fetch_skips_api_call_when_disconnecting() -> None:


### PR DESCRIPTION
## Summary
Make sure the AWS CRT background threads exit cleanly after MQTT disconnect to avoid the `_DeleteDummyThreadOnDel` finalizer warning.

## Changes
- added `MQTT.shutdown()` that waits for the CRT shutdown events after the client is fully disposed
- `WorxCloud.disconnect()` now calls `shutdown()` and clears `self.mqtt`
- extended `DummyMQTT` in `tests/test_api_lifecycle.py` with a `shutdown()` stub and assert it's invoked

## Testing
- `.venv/bin/pytest -q`

## Notes
- The log warning was triggered when the awscrt threads outlived the interpreter shutdown; now they are joined before program exit.
