### PR TITLE
Harden MQTT shutdown lifecycle for safer teardown

### DIFF
--- a/pyworxcloud/utils/mqtt.py
+++ b/pyworxcloud/utils/mqtt.py
@@ -134,6 +134,7 @@ class MQTT(LDict):
         self._pending_response_target: str | None = None
         self._pending_response_message_id: int | None = None
         self._last_command_payload: dict[str, Any] | None = None
+        self._lifecycle_lock = threading.RLock()
         if response_timeout <= 0:
             raise ValueError("response_timeout must be greater than 0")
         self._response_timeout = float(response_timeout)
@@ -317,51 +318,65 @@ class MQTT(LDict):
     def disconnect(self, keep_topic: bool = False):  # pylint: disable=unused-argument
         """Disconnect from AWSIoT MQTT server."""
         logger = self._log.getChild("MQTT_Disconnect")
+        with self._lifecycle_lock:
+            if self._shutdown_event:
+                self._is_connected = False
+                return
 
-        if self.connected:
             # Clear topic list
             if not keep_topic:
                 self._topic = []
 
-            # Disconnect
-            disconnect_future = self.client.disconnect()
-            disconnect_future.result()
+            client = self.client
+            if client is None:
+                self._is_connected = False
+                return
 
-            # Update state
-            self._is_connected = False
-            logger.debug("MQTT disconnected")
+            try:
+                if self._is_connected:
+                    disconnect_future = client.disconnect()
+                    disconnect_future.result()
+                    logger.debug("MQTT disconnected")
+            except Exception as err:  # pragma: no cover - defensive
+                logger.debug("MQTT disconnect raised during teardown: %s", err)
+            finally:
+                # Ensure internal state remains consistent after teardown attempts.
+                self._is_connected = False
 
     def shutdown(self) -> None:
         """Release background AWS CRT resources."""
-        if not self._shutdown_event:
+        with self._lifecycle_lock:
+            if self._shutdown_event:
+                return
             self._shutdown_event = True
 
-            # Force disconnect in case we're still connected.
-            if self.connected:
-                try:
-                    self.disconnect(keep_topic=True)
-                except Exception:  # pragma: no cover - defensive
-                    pass
-
-            self.client = None
             host_resolver = self._host_resolver
             client_bootstrap = self._client_bootstrap
             event_loop_group = self._event_loop_group
+            client = self.client
 
+            self.client = None
             self._host_resolver = None
             self._client_bootstrap = None
             self._event_loop_group = None
+            self._is_connected = False
 
-            if host_resolver is not None and hasattr(host_resolver, "shutdown_event"):
-                host_resolver.shutdown_event.wait(5)
-            if client_bootstrap is not None and hasattr(
-                client_bootstrap, "shutdown_event"
-            ):
-                client_bootstrap.shutdown_event.wait(5)
-            if event_loop_group is not None and hasattr(
-                event_loop_group, "shutdown_event"
-            ):
-                event_loop_group.shutdown_event.wait(5)
+        # Disconnect after detaching internals, so concurrent calls see teardown state.
+        if client is not None:
+            try:
+                disconnect_future = client.disconnect()
+                disconnect_future.result()
+            except Exception:  # pragma: no cover - defensive
+                pass
+
+        if host_resolver is not None and hasattr(host_resolver, "shutdown_event"):
+            host_resolver.shutdown_event.wait(5)
+        if client_bootstrap is not None and hasattr(
+            client_bootstrap, "shutdown_event"
+        ):
+            client_bootstrap.shutdown_event.wait(5)
+        if event_loop_group is not None and hasattr(event_loop_group, "shutdown_event"):
+            event_loop_group.shutdown_event.wait(5)
 
     def ping(
         self,

--- a/tests/test_mqtt_lifecycle.py
+++ b/tests/test_mqtt_lifecycle.py
@@ -1,0 +1,103 @@
+"""Tests for MQTT lifecycle teardown safety."""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Any
+
+from pyworxcloud.utils.mqtt import MQTT
+
+
+class _ImmediateFuture:
+    """Simple future stub with immediate completion."""
+
+    def result(self) -> None:
+        return None
+
+
+class _ClientStub:
+    """Client stub that records disconnect attempts."""
+
+    def __init__(self, should_raise: bool = False) -> None:
+        self.disconnect_calls = 0
+        self.should_raise = should_raise
+
+    def disconnect(self) -> _ImmediateFuture:
+        self.disconnect_calls += 1
+        if self.should_raise:
+            raise RuntimeError("disconnect failed")
+        return _ImmediateFuture()
+
+
+class _ShutdownEventStub:
+    """Stub exposing a wait() method used by AWS CRT resources."""
+
+    def __init__(self) -> None:
+        self.wait_calls = 0
+
+    def wait(self, _timeout: float) -> bool:
+        self.wait_calls += 1
+        return True
+
+
+class _ShutdownResourceStub:
+    """Resource stub with shutdown_event attribute."""
+
+    def __init__(self) -> None:
+        self.shutdown_event = _ShutdownEventStub()
+
+
+def _build_mqtt_lifecycle_fixture(
+    *, connected: bool = True, client: Any | None = None
+) -> MQTT:
+    mqtt = MQTT.__new__(MQTT)
+    mqtt._log = logging.getLogger("test")
+    mqtt._lifecycle_lock = threading.RLock()
+    mqtt._shutdown_event = False
+    mqtt._is_connected = connected
+    mqtt._topic = ["topic/out"]
+    mqtt.client = client
+    mqtt._host_resolver = _ShutdownResourceStub()
+    mqtt._client_bootstrap = _ShutdownResourceStub()
+    mqtt._event_loop_group = _ShutdownResourceStub()
+    return mqtt
+
+
+def test_disconnect_is_idempotent_and_safe_with_missing_client() -> None:
+    """Disconnect should be safe to call repeatedly and with no client."""
+    client = _ClientStub()
+    mqtt = _build_mqtt_lifecycle_fixture(client=client)
+
+    mqtt.disconnect()
+    mqtt.client = None
+    mqtt.disconnect()
+
+    assert client.disconnect_calls == 1
+    assert mqtt._is_connected is False
+
+
+def test_disconnect_swallows_teardown_disconnect_errors() -> None:
+    """Disconnect should keep teardown stable even when client disconnect fails."""
+    mqtt = _build_mqtt_lifecycle_fixture(client=_ClientStub(should_raise=True))
+
+    mqtt.disconnect()
+
+    assert mqtt._is_connected is False
+
+
+def test_shutdown_is_idempotent_and_detaches_resources() -> None:
+    """Shutdown should execute cleanup once and detach all AWS CRT resources."""
+    client = _ClientStub()
+    mqtt = _build_mqtt_lifecycle_fixture(client=client)
+
+    mqtt.shutdown()
+    mqtt.shutdown()
+
+    assert client.disconnect_calls == 1
+    assert mqtt.client is None
+    assert mqtt._host_resolver is None
+    assert mqtt._client_bootstrap is None
+    assert mqtt._event_loop_group is None
+    assert mqtt._shutdown_event is True
+    assert mqtt._is_connected is False


### PR DESCRIPTION
## Summary
Improve MQTT lifecycle teardown behavior to be idempotent and defensive during Home Assistant stop/unload and process shutdown.

## Changes
- Added `self._lifecycle_lock` to serialize MQTT lifecycle operations.
- Hardened `disconnect()` to safely handle repeated calls, missing client, and teardown races.
- Hardened `shutdown()` to be explicitly idempotent, detach resources once, and perform defensive disconnect.
- Added lifecycle-focused tests in `tests/test_mqtt_lifecycle.py`.

## Testing
- `python3 -m py_compile pyworxcloud/utils/mqtt.py tests/test_mqtt_lifecycle.py`
- `pytest -q tests/test_mqtt_lifecycle.py` (not run in this environment: `pytest` module missing)
- `pytest -q tests/test_mqtt_commands.py` (not run in this environment: `pytest` module missing)

## Notes
- Repository default branch is `master` on remote, so PR targets `master`.
- This change improves teardown robustness but may not fully eliminate third-party interpreter-shutdown noise from upstream runtime/library internals.
