### PR TITLE
Fix data sample validation and MQTT fixture assumptions

### DIFF
--- a/scripts/verify_data_samples.py
+++ b/scripts/verify_data_samples.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Iterable, NamedTuple
+from typing import Any, Generator, Iterable, NamedTuple
 
 
 class ValidationIssue(NamedTuple):
@@ -14,6 +14,23 @@ class ValidationIssue(NamedTuple):
 
 REQUIRED_CFG_KEYS = {"id"}
 REQUIRED_DAT_KEYS = {"conn"}
+
+
+def _iter_json_documents(text: str) -> Generator[dict[str, Any], None, None]:
+    """Yield all JSON objects stored sequentially in a file."""
+    decoder = json.JSONDecoder()
+    index = 0
+    length = len(text)
+
+    while index < length:
+        while index < length and text[index].isspace():
+            index += 1
+        if index >= length:
+            break
+        obj, consumed = decoder.raw_decode(text[index:])
+        if isinstance(obj, dict):
+            yield obj
+        index += consumed
 
 
 def _validate_payload(payload: dict[str, dict]) -> Iterable[str]:
@@ -46,18 +63,26 @@ def validate_data_samples(root: Path | None = None) -> list[ValidationIssue]:
 
     for file in sorted(root_path.rglob("*.json")):
         try:
-            data = json.loads(file.read_text(encoding="utf-8"))
+            text = file.read_text(encoding="utf-8")
+            data = list(_iter_json_documents(text))
         except json.JSONDecodeError as err:
             issues.append(ValidationIssue(file, f"invalid JSON: {err}"))
             continue
 
-        payload = data.get("payload")
-        if not isinstance(payload, dict):
-            issues.append(ValidationIssue(file, "missing payload dict"))
+        if not data:
+            issues.append(ValidationIssue(file, "no JSON objects found"))
             continue
 
-        for error in _validate_payload(payload):
-            issues.append(ValidationIssue(file, error))
+        for index, entry in enumerate(data, start=1):
+            payload = entry.get("payload")
+            if not isinstance(payload, dict):
+                issues.append(
+                    ValidationIssue(file, f"entry {index}: missing payload dict")
+                )
+                continue
+
+            for error in _validate_payload(payload):
+                issues.append(ValidationIssue(file, f"entry {index}: {error}"))
 
     return issues
 

--- a/tests/test_device_decode.py
+++ b/tests/test_device_decode.py
@@ -150,17 +150,25 @@ def test_devicehandler_handles_mqtt_payloads() -> None:
 
     for fixture_path in MQTT_FIXTURES:
         payloads = _load_payloads(fixture_path)
+        assert payloads
 
-    assert payloads
-    for index, payload in enumerate(payloads):
-        mower = _build_mower(payload, 1, f"MQTT Fixture {index}")
-        device = DeviceHandler(api=object(), mower=mower, tz="UTC")
+        for index, payload in enumerate(payloads):
+            mower = _build_mower(payload, 1, f"MQTT Fixture {index}")
+            device = DeviceHandler(api=object(), mower=mower, tz="UTC")
 
-        assert device.is_decoded is True
-        assert device.protocol == 1
-        assert device.raw_dat["mac"] == payload["dat"]["mac"]
-        sc_slots = payload["cfg"]["sc"].get("slots", [])
-        slots = device.schedules.get("slots", [])
-        assert slots
-        assert len(slots) == len(sc_slots)
-        assert any(slot["source"].startswith("protocol") for slot in slots)
+            assert device.is_decoded is True
+            assert device.protocol == 1
+            expected_mac = payload["dat"].get("mac")
+            if expected_mac is not None:
+                assert device.raw_dat["mac"] == expected_mac
+            else:
+                assert payload["dat"].get("uuid")
+                assert device.uuid == payload["dat"]["uuid"]
+            sc_slots = payload["cfg"]["sc"].get("slots", [])
+            slots = device.schedules.get("slots", [])
+            assert slots
+            if sc_slots:
+                assert len(slots) == len(sc_slots)
+                assert any(slot["source"].startswith("protocol") for slot in slots)
+            else:
+                assert any(slot.get("source") for slot in slots)


### PR DESCRIPTION
## Summary
Fix fixture validation and decode tests to correctly handle multi-document sample files and UUID-only MQTT payloads.

## Changes
- Updated `scripts/verify_data_samples.py` to parse sequential JSON documents in each sample file.
- Validated each JSON entry payload independently and reported entry-indexed issues.
- Updated `tests/test_device_decode.py` MQTT fixture assertions to support payloads without `dat.mac` when `uuid` is present.
- Relaxed slot source assertion for payloads that do not provide `cfg.sc.slots`.

## Testing
- `pytest -q tests/test_data_samples.py tests/test_device_decode.py`

## Notes
- Remote repository base branch is `master`, so PR targets `master`.
