### PR TITLE
Deprecate sync WorxCloud context manager usage

### DIFF
--- a/pyworxcloud/__init__.py
+++ b/pyworxcloud/__init__.py
@@ -9,6 +9,7 @@ import asyncio
 import json
 import logging
 import sys
+import warnings
 from datetime import datetime, timedelta
 from random import randint
 from typing import Any
@@ -196,6 +197,22 @@ class WorxCloud(dict):
 
     def __enter__(self) -> Any:
         """Compatibility helper for sync with usage."""
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            pass
+        else:
+            raise RuntimeError(
+                "Sync 'with WorxCloud(...)' cannot be used inside a running event loop. "
+                "Use 'async with WorxCloud(...)' instead."
+            )
+
+        warnings.warn(
+            "Sync context manager support is deprecated and will be removed in a future release. "
+            "Use 'async with WorxCloud(...)' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         self._sync_loop = asyncio.new_event_loop()
         self._sync_loop.run_until_complete(self.authenticate())
         self._sync_loop.run_until_complete(self.connect())

--- a/tests/test_api_lifecycle.py
+++ b/tests/test_api_lifecycle.py
@@ -306,6 +306,48 @@ def test_async_context_manager_disconnects_on_exception(monkeypatch) -> None:
     assert calls == ["auth", "connect", "disconnect"]
 
 
+def test_sync_context_manager_warns_deprecated(monkeypatch) -> None:
+    """Sync context manager should emit a deprecation warning."""
+    cloud = WorxCloud("user@example.com", "secret", "worx")
+
+    async def _noop_auth() -> bool:
+        return True
+
+    async def _noop_connect() -> bool:
+        return True
+
+    async def _noop_disconnect() -> None:
+        return None
+
+    monkeypatch.setattr(cloud, "authenticate", _noop_auth)
+    monkeypatch.setattr(cloud, "connect", _noop_connect)
+    monkeypatch.setattr(cloud, "disconnect", _noop_disconnect)
+
+    with pytest.deprecated_call():
+        cloud.__enter__()
+    cloud.__exit__(None, None, None)
+
+
+def test_sync_context_manager_fails_inside_running_loop(monkeypatch) -> None:
+    """Sync context manager should refuse execution in a running event loop."""
+    cloud = WorxCloud("user@example.com", "secret", "worx")
+
+    async def _noop_auth() -> bool:
+        return True
+
+    async def _noop_connect() -> bool:
+        return True
+
+    monkeypatch.setattr(cloud, "authenticate", _noop_auth)
+    monkeypatch.setattr(cloud, "connect", _noop_connect)
+
+    async def _run() -> None:
+        with pytest.raises(RuntimeError):
+            cloud.__enter__()
+
+    asyncio.run(_run())
+
+
 def test_match_mower_uses_identifier_priority() -> None:
     """Matcher should prefer serial, then uuid, then mac."""
     cloud = WorxCloud("user@example.com", "secret", "worx")


### PR DESCRIPTION
## Summary
Deprecate sync context manager usage for `WorxCloud` and make it fail fast when used inside a running event loop.

## Changes
- Added `DeprecationWarning` in `WorxCloud.__enter__` for sync `with` usage.
- Added explicit `RuntimeError` when sync context manager is called from an active event loop.
- Added tests for both deprecated behavior and active-loop guard.

## Testing
- `pytest -q tests/test_api_lifecycle.py`
- `pytest -q`

## Notes
- This PR does not remove sync context manager support yet; it only deprecates and hardens it.
