### PR TITLE
Improve MQTT timeout diagnostics

### DIFF
--- a/pyworxcloud/utils/mqtt.py
+++ b/pyworxcloud/utils/mqtt.py
@@ -490,10 +490,13 @@ class MQTT(LDict):
         # Format the message
         formatted_message = self.format_message(serial_number, message, protocol)
         command_message_id = json.loads(formatted_message)["id"]
+        identifier_type = "sn" if protocol == 0 else "uuid" if protocol == 1 else "id"
         self._last_command_payload = {
             "serial": serial_number,
+            "identifier_type": identifier_type,
             "topic": topic,
             "message": message,
+            "protocol": protocol,
             "command_id": command_message_id,
             "payload": formatted_message,
         }
@@ -524,8 +527,10 @@ class MQTT(LDict):
                 if not self._response_event.wait(effective_timeout):
                     payload = self._last_command_payload or {}
                     self._log.warning(
-                        "Timeout waiting for device response; serial=%s command_id=%s topic=%s payload=%s",
+                        "Timeout waiting for device response; identifier_type=%s identifier=%s protocol=%s command_id=%s topic=%s payload=%s",
+                        payload.get("identifier_type", identifier_type),
                         payload.get("serial", serial_number),
+                        payload.get("protocol", protocol),
                         payload.get("command_id"),
                         payload.get("topic"),
                         payload.get("payload"),

--- a/tests/test_mqtt_commands.py
+++ b/tests/test_mqtt_commands.py
@@ -79,6 +79,9 @@ def test_publish_times_out_when_no_response(
                 timeout=0.05,
             )
     assert "Timeout waiting for device response" in caplog.text
+    assert "identifier_type=sn" in caplog.text
+    assert "protocol=0" in caplog.text
+    assert "topic=topic/in" in caplog.text
 
 
 def test_publish_uses_default_response_timeout(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
Improve MQTT command timeout observability by logging richer metadata when response timeouts occur.

## Changes
- Added `identifier_type` and `protocol` metadata to tracked command payload context.
- Expanded timeout warning log fields to include identifier type, identifier, protocol, command id, and topic.
- Updated timeout test assertions to verify new observability fields.

## Testing
- `pytest -q tests/test_mqtt_commands.py`
- `pytest -q`

## Notes
- Behavior is unchanged; only timeout diagnostics are improved.
