### PR TITLE
Add async callback support to event dispatch

### DIFF
--- a/pyworxcloud/events.py
+++ b/pyworxcloud/events.py
@@ -3,6 +3,8 @@
 # pylint: disable=unnecessary-lambda
 from __future__ import annotations
 
+import asyncio
+import inspect
 import logging
 from enum import IntEnum
 from typing import Any
@@ -52,6 +54,21 @@ class EventHandler:
         """Set handler for a LandroidEvent"""
         self.__events.update({event: func})
 
+    @staticmethod
+    def _invoke(handler: Any, **kwargs) -> None:
+        """Invoke sync or async event handlers safely."""
+        result = handler(**kwargs)
+        if not inspect.isawaitable(result):
+            return
+
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            asyncio.run(result)
+            return
+
+        loop.create_task(result)
+
     def del_handler(self, event: LandroidEvent) -> None:
         """Remove a handler for a LandroidEvent."""
         self.__events.pop(event, None)
@@ -73,12 +90,12 @@ class EventHandler:
                 )
                 return False
 
-            self.__events[event](name=kwargs["name"], device=kwargs["device"])
+            self._invoke(self.__events[event], name=kwargs["name"], device=kwargs["device"])
             return True
         elif LandroidEvent.API == event:
             # Preferred API callback payload.
             if check_syntax(kwargs, ["api_data"], dict):
-                self.__events[event](api_data=kwargs["api_data"])
+                self._invoke(self.__events[event], api_data=kwargs["api_data"])
                 return True
 
             # Backward-compatible payload shape used in forced refresh flow.
@@ -87,7 +104,7 @@ class EventHandler:
             if check_syntax(kwargs, ["name"], str) and check_syntax(
                 kwargs, ["device"], DeviceHandler
             ):
-                self.__events[event](name=kwargs["name"], device=kwargs["device"])
+                self._invoke(self.__events[event], name=kwargs["name"], device=kwargs["device"])
                 return True
 
             _LOGGER.warning(
@@ -98,13 +115,13 @@ class EventHandler:
             if not check_syntax(kwargs, ["state"], bool):
                 return False
 
-            self.__events[event](state=kwargs["state"])
+            self._invoke(self.__events[event], state=kwargs["state"])
             return True
         elif LandroidEvent.MQTT_RATELIMIT == event:
             if not check_syntax(kwargs, ["message"], str):
                 return False
 
-            self.__events[event](message=kwargs["message"])
+            self._invoke(self.__events[event], message=kwargs["message"])
             return True
         elif LandroidEvent.MQTT_PUBLISH == event:
             if not check_syntax(kwargs, ["message", "device", "topic"], str):
@@ -116,7 +133,8 @@ class EventHandler:
             if not check_syntax(kwargs, ["retain"], bool):
                 return False
 
-            self.__events[event](
+            self._invoke(
+                self.__events[event],
                 message=kwargs["message"],
                 qos=kwargs["qos"],
                 retain=kwargs["retain"],
@@ -128,7 +146,8 @@ class EventHandler:
             if not check_syntax(kwargs, ["message", "level"], str):
                 return False
 
-            self.__events[event](
+            self._invoke(
+                self.__events[event],
                 message=kwargs["message"],
                 level=kwargs["level"],
             )

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+
 from pyworxcloud.events import EventHandler, LandroidEvent
 
 
@@ -59,3 +61,35 @@ def test_api_event_rejects_invalid_payload() -> None:
     result = handler.call(LandroidEvent.API, message="invalid")
 
     assert result is False
+
+
+def test_event_handler_supports_async_callback_inside_running_loop() -> None:
+    """Async callbacks should be scheduled when called from an active loop."""
+    handler = EventHandler()
+    calls: list[bool] = []
+
+    async def _on_conn(state: bool) -> None:
+        calls.append(state)
+
+    handler.set_handler(LandroidEvent.MQTT_CONNECTION, _on_conn)
+
+    async def _run() -> None:
+        assert handler.call(LandroidEvent.MQTT_CONNECTION, state=True) is True
+        await asyncio.sleep(0)
+
+    asyncio.run(_run())
+    assert calls == [True]
+
+
+def test_event_handler_supports_async_callback_without_running_loop() -> None:
+    """Async callbacks should run to completion even without active loop."""
+    handler = EventHandler()
+    calls: list[dict] = []
+
+    async def _on_api(api_data: dict) -> None:
+        calls.append(api_data)
+
+    handler.set_handler(LandroidEvent.API, _on_api)
+
+    assert handler.call(LandroidEvent.API, api_data={"status": "ok"}) is True
+    assert calls == [{"status": "ok"}]


### PR DESCRIPTION
## Summary
Add async callback support to `EventHandler` so integrations can register coroutine handlers safely.

## Changes
- Added async-aware event invocation helper in `EventHandler`.
- If callback returns an awaitable:
  - schedule via `create_task()` when loop is running
  - run to completion via `asyncio.run()` when no loop is running
- Updated all event dispatch paths to use the new invoke helper.
- Added tests for async callback behavior with and without running event loop.

## Testing
- `pytest -q tests/test_events.py`
- `pytest -q`

## Notes
- Sync callback behavior remains unchanged.
