### PR TITLE
Add optional in-flight command deduplication

### DIFF
--- a/pyworxcloud/__init__.py
+++ b/pyworxcloud/__init__.py
@@ -69,6 +69,7 @@ class WorxCloud(dict):
         verify_ssl: bool = True,
         tz: str | None = None,  # pylint: disable=invalid-name
         command_timeout: float = DEFAULT_COMMAND_TIMEOUT,
+        deduplicate_inflight_commands: bool = False,
     ) -> None:
         """
         Initialize :class:WorxCloud class and set default attribute values.
@@ -160,6 +161,7 @@ class WorxCloud(dict):
         if command_timeout <= 0:
             raise ValueError("command_timeout must be greater than 0")
         self._command_timeout = float(command_timeout)
+        self._deduplicate_inflight_commands = bool(deduplicate_inflight_commands)
         _LOGGER.debug("Initializing EventHandler ...")
         self._events = EventHandler()
 
@@ -303,6 +305,7 @@ class WorxCloud(dict):
             self._log,
             self._on_update,
             identifier_resolver=self._resolve_mower_identifiers,
+            deduplicate_inflight_commands=self._deduplicate_inflight_commands,
             response_timeout=self._command_timeout,
         )
 

--- a/pyworxcloud/utils/mqtt.py
+++ b/pyworxcloud/utils/mqtt.py
@@ -114,6 +114,7 @@ class MQTT(LDict):
         logger: Logger,
         callback: Any,
         identifier_resolver: Callable[[str], set[str]] | None = None,
+        deduplicate_inflight_commands: bool = False,
         response_timeout: float = DEFAULT_RESPONSE_TIMEOUT,
     ) -> dict:
         """Initialize AWSIoT MQTT handler."""
@@ -122,6 +123,7 @@ class MQTT(LDict):
         self._events = EventHandler()
         self._on_update = callback
         self._identifier_resolver = identifier_resolver
+        self._deduplicate_inflight_commands = deduplicate_inflight_commands
         self._endpoint = endpoint
         self._log = logger.getChild("MQTT")
         self._reconnected: bool = False
@@ -137,6 +139,7 @@ class MQTT(LDict):
         self._response_event = threading.Event()
         self._pending_response_target: str | None = None
         self._pending_response_message_id: int | None = None
+        self._pending_command_signature: tuple[str, str, int, str] | None = None
         self._last_command_payload: dict[str, Any] | None = None
         self._lifecycle_lock = threading.RLock()
         self._message_id_lock = threading.Lock()
@@ -487,6 +490,24 @@ class MQTT(LDict):
         if not self.connected:
             self.update_token()
 
+        command_signature = (
+            serial_number,
+            topic,
+            protocol,
+            json.dumps(message, sort_keys=True, separators=(",", ":")),
+        )
+        if self._deduplicate_inflight_commands and self._command_lock.locked():
+            with self._response_lock:
+                if self._pending_command_signature == command_signature:
+                    self._log.debug(
+                        "Dropping duplicate in-flight command serial=%s topic=%s protocol=%s message=%s",
+                        serial_number,
+                        topic,
+                        protocol,
+                        message,
+                    )
+                    return
+
         # Format the message
         formatted_message = self.format_message(serial_number, message, protocol)
         command_message_id = json.loads(formatted_message)["id"]
@@ -510,6 +531,7 @@ class MQTT(LDict):
             with self._response_lock:
                 self._pending_response_target = serial_number
                 self._pending_response_message_id = command_message_id
+                self._pending_command_signature = command_signature
                 self._response_event.clear()
 
             try:
@@ -537,6 +559,7 @@ class MQTT(LDict):
                 with self._response_lock:
                     self._pending_response_target = None
                     self._pending_response_message_id = None
+                    self._pending_command_signature = None
                     self._response_event.clear()
 
     async def apublish(

--- a/tests/test_api_lifecycle.py
+++ b/tests/test_api_lifecycle.py
@@ -58,8 +58,10 @@ class CapturingMQTT:
         _callback: Any,
         response_timeout: float,
         identifier_resolver: Any = None,
+        deduplicate_inflight_commands: bool = False,
     ) -> None:
         self.identifier_resolver = identifier_resolver
+        self.deduplicate_inflight_commands = deduplicate_inflight_commands
         self.__class__.last_response_timeout = response_timeout
 
     async def aconnect(self) -> None:

--- a/tests/test_mqtt_commands.py
+++ b/tests/test_mqtt_commands.py
@@ -43,6 +43,7 @@ def _build_mqtt(
     monkeypatch: pytest.MonkeyPatch,
     response_timeout: float = 30.0,
     identifier_resolver: Any | None = None,
+    deduplicate_inflight_commands: bool = False,
 ) -> tuple[MQTT, _DummyClient]:
     dummy_client = _DummyClient()
     dummy_api = type("API", (), {"access_token": "a.b.c"})()
@@ -57,6 +58,7 @@ def _build_mqtt(
         logger=logging.getLogger("test"),
         callback=lambda _payload: None,
         identifier_resolver=identifier_resolver,
+        deduplicate_inflight_commands=deduplicate_inflight_commands,
         response_timeout=response_timeout,
     )
     mqtt._is_connected = True
@@ -282,3 +284,43 @@ def test_format_message_rejects_unsupported_protocol(
 
     with pytest.raises(ValueError):
         mqtt.format_message("SN-1", {"cmd": 1}, 99)
+
+
+def test_publish_drops_duplicate_inflight_command_when_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Duplicate in-flight command should be dropped when dedup is enabled."""
+    mqtt, dummy = _build_mqtt(monkeypatch, deduplicate_inflight_commands=True)
+
+    def _publish_once() -> None:
+        mqtt.publish(
+            serial_number="SN-1",
+            topic="topic/in",
+            message={"cmd": 1},
+            protocol=0,
+            timeout=1.0,
+        )
+
+    first = threading.Thread(target=_publish_once)
+    second = threading.Thread(target=_publish_once)
+    first.start()
+
+    deadline = time.time() + 1.0
+    while len(dummy.published) < 1 and time.time() < deadline:
+        time.sleep(0.01)
+    assert len(dummy.published) == 1
+
+    second.start()
+    time.sleep(0.1)
+    assert len(dummy.published) == 1
+
+    payload = json.loads(dummy.published[0]["payload"])
+    mqtt._on_message_received(
+        "topic/out",
+        json.dumps({"cfg": {"sn": "SN-1", "id": payload["id"]}}).encode("utf-8"),
+    )
+
+    first.join(timeout=1.0)
+    second.join(timeout=1.0)
+    assert first.is_alive() is False
+    assert second.is_alive() is False


### PR DESCRIPTION
## Summary
Add optional deduplication for identical in-flight MQTT commands to reduce redundant command spam in fast automation loops.

## Changes
- Added `deduplicate_inflight_commands` option to `WorxCloud` and MQTT layer (default `False`).
- Added command signature tracking (`serial/topic/protocol/message`) for in-flight command context.
- When dedup is enabled, duplicate commands matching current in-flight signature are dropped.
- Added tests for dedup behavior and constructor propagation.

## Testing
- `pytest -q tests/test_mqtt_commands.py tests/test_api_lifecycle.py`
- `pytest -q`

## Notes
- Default behavior remains unchanged (`deduplicate_inflight_commands=False`).
