### PR TITLE
Add async migration cheat sheet docs

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -32,6 +32,24 @@ What this means for integrations:
 - Ensure lifecycle setup/teardown runs inside an event loop.
 - For Home Assistant, call methods from async setup/update/service handlers directly.
 
+Quick before/after:
+
+```python
+# Before
+cloud.authenticate()
+cloud.connect()
+cloud.update("SERIAL")
+cloud.disconnect()
+```
+
+```python
+# After
+await cloud.authenticate()
+await cloud.connect()
+await cloud.update("SERIAL")
+await cloud.disconnect()
+```
+
 ### 1. MQTT commands are now serialized
 
 Only one command can be in flight per MQTT client at a time.

--- a/README.md
+++ b/README.md
@@ -44,6 +44,28 @@ async with WorxCloud("user@example.com", "secret", "worx") as cloud:
     ...
 ```
 
+### Async migration cheat sheet
+
+Before (sync):
+
+```python
+cloud = WorxCloud("user@example.com", "secret", "worx")
+cloud.authenticate()
+cloud.connect()
+cloud.start("SERIAL")
+cloud.disconnect()
+```
+
+After (async):
+
+```python
+cloud = WorxCloud("user@example.com", "secret", "worx")
+await cloud.authenticate()
+await cloud.connect()
+await cloud.start("SERIAL")
+await cloud.disconnect()
+```
+
 ## Testing
 
 Run tests locally with:


### PR DESCRIPTION
## Summary
Add concise async migration cheat-sheet examples to README and migration guide.

## Changes
- Added sync-vs-async before/after snippets in `README.md`.
- Added quick migration example block in `MIGRATION.md` under async-first breaking change section.

## Testing
- `pytest -q`

## Notes
- Documentation-only enhancement to make migration steps easier to apply quickly.
