### PR TITLE
Fix battery cycle decoding

### DIFF
--- a/pyworxcloud/utils/battery.py
+++ b/pyworxcloud/utils/battery.py
@@ -28,6 +28,13 @@ CHARGE_MAP = {
 class Battery(LDict):
     """Battery information."""
 
+    @staticmethod
+    def _read_value(indata: Any, key: str) -> Any | None:
+        """Read a battery counter field from either a dict or object."""
+        if isinstance(indata, dict):
+            return indata.get(key)
+        return getattr(indata, key, None)
+
     def __init__(
         self, indata: list | None = None, cycle_info: Any | None = None
     ) -> None:
@@ -76,6 +83,7 @@ class Battery(LDict):
             self["charging"] = CHARGE_MAP[indata["c"]]
         if "nr" in indata:
             self["cycles"].update({"total": indata["nr"]})
+            self._update_cycles()
 
     def _update_cycles(self) -> None:
         """Update cycles info."""
@@ -95,34 +103,24 @@ class Battery(LDict):
         """Set battery cycles information."""
         from ..helpers import string_to_time
 
-        if self["cycles"]["total"] == 0:
-            self["cycles"].update({"total": indata.battery_charge_cycles})
+        total_cycles = self._read_value(indata, "battery_charge_cycles")
+        if total_cycles is not None and self["cycles"]["total"] == 0:
+            self["cycles"].update({"total": int(total_cycles)})
 
-        if indata.battery_charge_cycles_reset is not None:
-            if self["cycles"]["total"] == 0:
-                self["cycles"].update(
-                    {
-                        "current": int(
-                            self["cycles"]["total"] - indata.battery_charge_cycles_reset
-                        )
-                    }
-                )
-                if self["cycles"]["current"] < 0:
-                    self["cycles"].update({"current": 0})
+        reset_at = self._read_value(indata, "battery_charge_cycles_reset")
+        reset_time = self._read_value(indata, "battery_charge_cycles_reset_at")
+        time_zone = self._read_value(indata, "time_zone")
+
+        if reset_at is not None:
             self["cycles"].update(
                 {
-                    "reset_at": int(indata.battery_charge_cycles_reset),
+                    "reset_at": int(reset_at),
                     "reset_time": (
-                        string_to_time(
-                            indata.battery_charge_cycles_reset_at, indata.time_zone
-                        )
-                        if not isinstance(
-                            indata.battery_charge_cycles_reset_at, type(None)
-                        )
+                        string_to_time(reset_time, time_zone)
+                        if not isinstance(reset_time, type(None))
                         else None
                     ),
                 }
             )
-        else:
-            if self["cycles"]["total"] > 0:
-                self["cycles"].update({"current": self["cycles"]["total"]})
+
+        self._update_cycles()

--- a/pyworxcloud/utils/devices.py
+++ b/pyworxcloud/utils/devices.py
@@ -125,7 +125,7 @@ class DeviceHandler(LDict):
         if not "time_zone" in data:
             data["time_zone"] = "UTC"
 
-        self.battery = Battery(data)
+        self.battery = Battery(data, data)
         self.blades = Blades(data)
         self.error = States(StateType.ERROR)
         self.orientation = Orientation([0, 0, 0])

--- a/tests/test_device_decode.py
+++ b/tests/test_device_decode.py
@@ -141,6 +141,43 @@ def test_devicehandler_exposes_raw_cfg_dat() -> None:
     assert device.raindelay_active == bool(str(payload["dat"]["rain"]["s"]) == "1")
 
 
+def test_devicehandler_updates_battery_cycle_current_from_live_nr() -> None:
+    """Realtime battery totals should recalculate the current cycle count."""
+    payload = {
+        "cfg": {
+            "id": 1,
+            "sn": "SERIAL-BATTERY",
+            "rd": 0,
+            "sc": {"d": [], "dd": False},
+            "tm": "12:00:00",
+            "dt": "11/03/2026",
+            "tz": "UTC",
+        },
+        "dat": {
+            "uuid": "UUID-BATTERY",
+            "mac": "AA:BB:CC:DD:EE:FF",
+            "conn": "online",
+            "ls": 1,
+            "le": 0,
+            "bt": {"t": 20, "v": 20.1, "p": 95, "c": 0, "nr": 211},
+            "rain": {"s": 0, "cnt": 0},
+        },
+    }
+    mower = _build_mower(payload, 0, "Battery Fixture")
+    mower["battery_charge_cycles"] = 209
+    mower["battery_charge_cycles_reset"] = 0
+    mower["battery_charge_cycles_reset_at"] = None
+
+    device = DeviceHandler(api=object(), mower=mower, tz="UTC")
+
+    assert device.battery["cycles"] == {
+        "total": 211,
+        "current": 211,
+        "reset_at": 0,
+        "reset_time": None,
+    }
+
+
 MQTT_FIXTURES = tuple(fixture_paths("mqtt.json"))
 
 


### PR DESCRIPTION
Summary
Fix battery cycle decoding so API counter metadata and live battery totals produce the correct current cycle count.

Changes
- pass API battery counter fields into `Battery` during device mapping
- recalculate `cycles.current` when live `dat.bt.nr` updates the total
- support reading battery counter fields from dict-backed mower payloads
- add a regression test covering the live battery cycle scenario

Testing
- python3 -m pytest -q
- live login using credentials from `.env` confirmed `payload bt.nr=211` decodes to `cycles.total=211` and `cycles.current=211`

Notes
- Repository default branch is currently `master`, so this PR targets `master` instead of `main`
