### PR TITLE
Add time extension command

### DIFF
--- a/pyworxcloud/__init__.py
+++ b/pyworxcloud/__init__.py
@@ -606,8 +606,13 @@ class WorxCloud(dict):
         return value
 
     @staticmethod
-    def _coerce_int(value: Any, name: str, minimum: int | None = None) -> int:
-        """Coerce an integer-like input and optionally enforce a minimum."""
+    def _coerce_int(
+        value: Any,
+        name: str,
+        minimum: int | None = None,
+        maximum: int | None = None,
+    ) -> int:
+        """Coerce an integer-like input and optionally enforce bounds."""
         if isinstance(value, bool):
             raise ValueError(f"{name} must be an integer value")
         try:
@@ -616,7 +621,16 @@ class WorxCloud(dict):
             raise ValueError(f"{name} must be an integer value") from err
         if minimum is not None and parsed < minimum:
             raise ValueError(f"{name} must be greater than or equal to {minimum}")
+        if maximum is not None and parsed > maximum:
+            raise ValueError(f"{name} must be less than or equal to {maximum}")
         return parsed
+
+    @staticmethod
+    def _require_step(value: int, name: str, step: int) -> int:
+        """Require that an integer value follows the documented step size."""
+        if value % step != 0:
+            raise ValueError(f"{name} must be in steps of {step}")
+        return value
 
     async def update(self, serial_number: str) -> None:
         """Request a state refresh."""
@@ -1000,6 +1014,31 @@ class WorxCloud(dict):
                 serial_number if mower["protocol"] == 0 else mower["uuid"],
                 mower["mqtt_topics"]["command_in"],
                 {"sc": {"m": 1}} if enable else {"sc": {"m": 0}},
+                mower["protocol"],
+            )
+        else:
+            raise OfflineError("The device is currently offline, no action was sent.")
+
+    async def set_time_extension(self, serial_number: str, time_extension: int) -> None:
+        """Set schedule time extension percentage.
+
+        Args:
+            serial_number (str): Serial number of the device
+            time_extension (int): Schedule time extension percentage.
+
+        Raises:
+            OfflineError: Raised if the device is offline.
+        """
+        time_extension = self._coerce_int(
+            time_extension, "time_extension", minimum=-100, maximum=100
+        )
+        time_extension = self._require_step(time_extension, "time_extension", 10)
+        mower = self.get_mower(serial_number)
+        if mower["online"]:
+            await self.mqtt.apublish(
+                serial_number if mower["protocol"] == 0 else mower["uuid"],
+                mower["mqtt_topics"]["command_in"],
+                {"sc": {"p": time_extension}},
                 mower["protocol"],
             )
         else:

--- a/tests/test_api_lifecycle.py
+++ b/tests/test_api_lifecycle.py
@@ -36,6 +36,11 @@ class DummyMQTT:
     async def ashutdown(self) -> None:
         self.shutdown_called = True
 
+    async def apublish(
+        self, _serial: str, _topic: str, _message: Any, _protocol: int | None = None
+    ) -> None:
+        return None
+
 
 class DummyDevice:
     """Simple device stub."""
@@ -412,6 +417,10 @@ def test_input_helpers_validate_types() -> None:
         cloud._coerce_int("abc", "runtime")
     with pytest.raises(ValueError):
         cloud._coerce_int(-1, "runtime", minimum=0)
+    with pytest.raises(ValueError):
+        cloud._coerce_int(101, "runtime", maximum=100)
+    with pytest.raises(ValueError):
+        cloud._require_step(25, "runtime", 10)
 
 
 def test_set_lock_rejects_non_bool_input_early(monkeypatch) -> None:
@@ -425,3 +434,68 @@ def test_set_lock_rejects_non_bool_input_early(monkeypatch) -> None:
 
     with pytest.raises(ValueError):
         asyncio.run(cloud.set_lock("SERIAL-1", "true"))
+
+
+def test_set_time_extension_rejects_out_of_range_input_early(monkeypatch) -> None:
+    """set_time_extension should validate the percentage before mower lookup."""
+    cloud = WorxCloud("user@example.com", "secret", "worx")
+
+    def _unexpected_lookup(_serial: str) -> dict:
+        raise AssertionError("get_mower should not be called for invalid int input")
+
+    monkeypatch.setattr(cloud, "get_mower", _unexpected_lookup)
+
+    with pytest.raises(ValueError):
+        asyncio.run(cloud.set_time_extension("SERIAL-1", -101))
+    with pytest.raises(ValueError):
+        asyncio.run(cloud.set_time_extension("SERIAL-1", 101))
+    with pytest.raises(ValueError):
+        asyncio.run(cloud.set_time_extension("SERIAL-1", 25))
+
+
+def test_set_time_extension_publishes_schedule_payload() -> None:
+    """set_time_extension should publish the documented sc.p payload."""
+    cloud = WorxCloud("user@example.com", "secret", "worx")
+    calls: list[dict[str, Any]] = []
+
+    class CapturingMQTT(DummyMQTT):
+        async def apublish(
+            self,
+            serial: str,
+            topic: str,
+            message: Any,
+            protocol: int | None = None,
+        ) -> None:
+            calls.append(
+                {
+                    "serial": serial,
+                    "topic": topic,
+                    "message": message,
+                    "protocol": protocol,
+                }
+            )
+
+    cloud.mqtt = CapturingMQTT()
+    cloud._mowers = [
+        {
+            "name": "Target",
+            "serial_number": "SERIAL-1",
+            "uuid": "UUID-1",
+            "mac_address": "MAC-1",
+            "online": True,
+            "protocol": 1,
+            "mqtt_topics": {"command_in": "topic/in"},
+        }
+    ]
+    cloud._rebuild_mower_indices()
+
+    asyncio.run(cloud.set_time_extension("SERIAL-1", 20))
+
+    assert calls == [
+        {
+            "serial": "UUID-1",
+            "topic": "topic/in",
+            "message": {"sc": {"p": 20}},
+            "protocol": 1,
+        }
+    ]


### PR DESCRIPTION
## Summary\n- add a pyworxcloud command for setting schedule time extension via \n- validate the accepted range as \n- validate that values are only set in 10 percent steps\n\n## Testing\n- python -m pytest -q tests/test_api_lifecycle.py\n\n## Known limitations\n- no change to published package version in this PR\n