### PR TITLE
Avoid duplicate logger handlers

### DIFF
--- a/pyworxcloud/helpers/logger.py
+++ b/pyworxcloud/helpers/logger.py
@@ -16,11 +16,11 @@ def get_logger(name: str) -> logging.Logger:
     )
 
     # configure stream handler
-    consoleHandler = logging.StreamHandler()
-    consoleHandler.setFormatter(logFormatter)
+    console_handler = logging.StreamHandler()
+    console_handler.setFormatter(logFormatter)
 
-    if not len(logger.root.handlers):
+    if not logger.handlers:
         logger.setLevel(logging.DEBUG)
-        logger.addHandler(consoleHandler)
+        logger.addHandler(console_handler)
 
     return logger

--- a/tests/test_api_lifecycle.py
+++ b/tests/test_api_lifecycle.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from typing import Any
 
 import pytest
@@ -11,6 +12,7 @@ from pyworxcloud import WorxCloud
 from pyworxcloud.api import LandroidCloudAPI
 from pyworxcloud.clouds import CloudType
 from pyworxcloud.events import LandroidEvent
+from pyworxcloud.helpers.logger import get_logger
 
 
 class DummyTimer:
@@ -208,6 +210,29 @@ def test_token_updated_is_noop_without_mqtt() -> None:
     cloud = WorxCloud("user@example.com", "secret", "worx")
     cloud.mqtt = None
     asyncio.run(cloud._token_updated())
+
+
+def test_get_logger_does_not_accumulate_handlers() -> None:
+    """Repeated logger setup should reuse the existing handler."""
+    logger = logging.getLogger("pyworxcloud.test_handlers")
+    original_handlers = list(logger.handlers)
+    original_level = logger.level
+
+    try:
+        logger.handlers.clear()
+        logger.setLevel(logging.NOTSET)
+
+        first = get_logger("pyworxcloud.test_handlers")
+        second = get_logger("pyworxcloud.test_handlers")
+
+        assert first is second
+        assert len(first.handlers) == 1
+        assert isinstance(first.handlers[0], logging.StreamHandler)
+    finally:
+        logger.handlers.clear()
+        logger.setLevel(original_level)
+        for handler in original_handlers:
+            logger.addHandler(handler)
 
 
 def test_on_api_update_dispatches_api_event_callback() -> None:


### PR DESCRIPTION
## Summary\nFix logger setup so repeated  instances reuse the existing  stream handler instead of adding a new handler each time.\n\n## Testing\n- python3 -m pytest -q tests/test_api_lifecycle.py\n- python3 -m pytest -q tests/test_api_lifecycle.py tests/test_mqtt_lifecycle.py\n\n## Known limitations\n- Does not address file descriptor teardown directly; this change only fixes duplicate log output from repeated logger handler registration.\n\nFixes #1013