### PR TITLE
Use standard library logging behavior

### DIFF
--- a/pyworxcloud/helpers/logger.py
+++ b/pyworxcloud/helpers/logger.py
@@ -4,23 +4,14 @@ from __future__ import annotations
 
 import logging
 
+PACKAGE_LOGGER_NAME = "pyworxcloud"
+
 
 def get_logger(name: str) -> logging.Logger:
-    """Configure the logger component."""
+    """Return a standard library logger for this package."""
 
-    logger = logging.getLogger(name)
+    package_logger = logging.getLogger(PACKAGE_LOGGER_NAME)
+    if not any(isinstance(handler, logging.NullHandler) for handler in package_logger.handlers):
+        package_logger.addHandler(logging.NullHandler())
 
-    # configure log formatter
-    logFormatter = logging.Formatter(
-        "%(asctime)s [%(filename)s] [%(funcName)s] [%(levelname)s] [%(lineno)d] %(message)s"
-    )
-
-    # configure stream handler
-    console_handler = logging.StreamHandler()
-    console_handler.setFormatter(logFormatter)
-
-    if not logger.handlers:
-        logger.setLevel(logging.DEBUG)
-        logger.addHandler(console_handler)
-
-    return logger
+    return logging.getLogger(name)

--- a/test_dashboard.py
+++ b/test_dashboard.py
@@ -50,6 +50,7 @@ def _configure_logging() -> int:
     """Configure runtime log verbosity for interactive dashboard use."""
     level_name = environ.get("DASHBOARD_LOG_LEVEL", "WARNING").upper()
     level = getattr(logging, level_name, logging.WARNING)
+    logging.basicConfig(level=level)
     for name in (
         "pyworxcloud",
         "pyworxcloud.events",
@@ -57,8 +58,6 @@ def _configure_logging() -> int:
     ):
         logger = logging.getLogger(name)
         logger.setLevel(level)
-        for handler in logger.handlers:
-            handler.setLevel(level)
     return level
 
 
@@ -383,11 +382,7 @@ async def main() -> None:
     cloud_type = environ.get("TYPE") or await _ainput("TYPE (worx/kress/landxcape): ")
 
     cloud = WorxCloud(email, password, cloud_type, tz="Europe/Copenhagen")
-    # WorxCloud initializes its own logger to DEBUG in get_logger().
-    # Re-apply chosen dashboard log level after instance creation.
     cloud._log.setLevel(log_level)
-    for handler in cloud._log.handlers:
-        handler.setLevel(log_level)
     _configure_logging()
     await cloud.authenticate()
     await cloud.connect()

--- a/test_dashboard_gui.py
+++ b/test_dashboard_gui.py
@@ -48,11 +48,10 @@ def _load_dotenv(path: str = ".env") -> None:
 def _configure_logging() -> int:
     level_name = environ.get("DASHBOARD_LOG_LEVEL", "WARNING").upper()
     level = getattr(logging, level_name, logging.WARNING)
+    logging.basicConfig(level=level)
     for name in ("pyworxcloud", "pyworxcloud.events", "pyworxcloud.utils.mqtt"):
         logger = logging.getLogger(name)
         logger.setLevel(level)
-        for handler in logger.handlers:
-            handler.setLevel(level)
     return level
 
 
@@ -213,8 +212,6 @@ class CloudWorker:
 
         self._cloud = WorxCloud(email, password, cloud_type, tz="Europe/Copenhagen")
         self._cloud._log.setLevel(self._log_level)
-        for handler in self._cloud._log.handlers:
-            handler.setLevel(self._log_level)
         _configure_logging()
 
         def _on_data(name: str, device: DeviceHandler) -> None:

--- a/test_listen.py
+++ b/test_listen.py
@@ -1,9 +1,12 @@
 import asyncio
+import logging
 from os import environ
 
 from pyworxcloud import WorxCloud
 from pyworxcloud.events import LandroidEvent
 from pyworxcloud.utils import DeviceHandler
+
+logging.basicConfig(level=logging.DEBUG)
 
 EMAIL = environ["EMAIL"]
 PASS = environ["PASSWORD"]

--- a/test_with.py
+++ b/test_with.py
@@ -1,11 +1,14 @@
 """Testfile demonstrating the "with method" of calling the module."""
 
+import logging
 from os import environ
 from pprint import pprint
 
 from pyworxcloud import WorxCloud
 from pyworxcloud.events import LandroidEvent
 from pyworxcloud.utils.devices import DeviceHandler
+
+logging.basicConfig(level=logging.DEBUG)
 
 EMAIL = environ["EMAIL"]
 PASS = environ["PASSWORD"]

--- a/tests/test_api_lifecycle.py
+++ b/tests/test_api_lifecycle.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import logging
 from typing import Any
 
 import pytest
@@ -12,7 +11,7 @@ from pyworxcloud import WorxCloud
 from pyworxcloud.api import LandroidCloudAPI
 from pyworxcloud.clouds import CloudType
 from pyworxcloud.events import LandroidEvent
-from pyworxcloud.helpers.logger import get_logger
+from pyworxcloud.helpers.logger import PACKAGE_LOGGER_NAME, get_logger
 
 
 class DummyTimer:
@@ -263,26 +262,29 @@ def test_token_updated_is_noop_without_mqtt() -> None:
 
 
 def test_get_logger_does_not_accumulate_handlers() -> None:
-    """Repeated logger setup should reuse the existing handler."""
-    logger = logging.getLogger("pyworxcloud.test_handlers")
-    original_handlers = list(logger.handlers)
-    original_level = logger.level
+    """Repeated logger setup should not attach output handlers or force levels."""
+    logger = get_logger("pyworxcloud.test_handlers")
+    package_logger = get_logger(PACKAGE_LOGGER_NAME)
+    original_handlers = list(package_logger.handlers)
+    original_level = package_logger.level
 
     try:
-        logger.handlers.clear()
-        logger.setLevel(logging.NOTSET)
+        package_logger.handlers.clear()
+        package_logger.setLevel(0)
 
         first = get_logger("pyworxcloud.test_handlers")
         second = get_logger("pyworxcloud.test_handlers")
 
         assert first is second
-        assert len(first.handlers) == 1
-        assert isinstance(first.handlers[0], logging.StreamHandler)
+        assert first.handlers == []
+        assert package_logger.level == 0
+        assert len(package_logger.handlers) == 1
+        assert package_logger.handlers[0].__class__.__name__ == "NullHandler"
     finally:
-        logger.handlers.clear()
-        logger.setLevel(original_level)
+        package_logger.handlers.clear()
+        package_logger.setLevel(original_level)
         for handler in original_handlers:
-            logger.addHandler(handler)
+            package_logger.addHandler(handler)
 
 
 def test_on_api_update_dispatches_api_event_callback() -> None:


### PR DESCRIPTION
## Summary
Stop configuring output handlers inside pyworxcloud itself and switch to standard library logging behavior with a package NullHandler. Update the manual example scripts to configure logging explicitly at the application layer.

## Testing
- python3 -m py_compile test.py test_listen.py test_with.py test_dashboard.py test_dashboard_gui.py pyworxcloud/helpers/logger.py
- python3 -m pytest -q tests/test_api_lifecycle.py tests/test_mqtt_lifecycle.py

## Known limitations
- Standalone users now need to configure logging themselves if they want console output, which is the intended library behavior.
