### PR TITLE
Prefer device timezone for schedules

### DIFF
--- a/pyworxcloud/utils/devices.py
+++ b/pyworxcloud/utils/devices.py
@@ -152,7 +152,7 @@ class DeviceHandler(LDict):
 
         self.mac_address = None
         self.protocol = 0
-        self.time_zone = None
+        self.time_zone = data.get("time_zone")
 
         for attr in UNWANTED_ATTRIBS:
             if hasattr(self, attr):
@@ -213,11 +213,17 @@ class DeviceHandler(LDict):
 
         self.updated = self._determine_updated_at(cfg_payload, dat_payload)
 
-        self.schedules.update_progress_and_next(
-            tz=self._tz if not isinstance(self._tz, type(None)) else self.time_zone
+        effective_timezone = (
+            self._tz
+            if not isinstance(self._tz, type(None))
+            else self.time_zone if self.time_zone is not None else "UTC"
         )
 
-        convert_to_time(self.name, self, self._tz, callback=self.update_attribute)
+        self.schedules.update_progress_and_next(tz=effective_timezone)
+
+        convert_to_time(
+            self.name, self, effective_timezone, callback=self.update_attribute
+        )
 
         mower["last_status"]["timestamp"] = self.updated
 

--- a/tests/test_device_decode.py
+++ b/tests/test_device_decode.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Any, Sequence, Tuple
 
 import pytest
+from zoneinfo import ZoneInfo
 
 from pyworxcloud.utils.capability import DeviceCapability
 from pyworxcloud.utils.devices import DeviceHandler
@@ -176,6 +177,21 @@ def test_devicehandler_updates_battery_cycle_current_from_live_nr() -> None:
         "reset_at": 0,
         "reset_time": None,
     }
+
+
+def test_devicehandler_uses_device_timezone_when_instance_timezone_is_missing() -> None:
+    """Schedule timestamps should fall back to device timezone before UTC."""
+    _, payload = _find_http_fixture(
+        lambda p: bool(p.get("cfg", {}).get("tz"))
+        and bool(p.get("cfg", {}).get("sc", {}).get("slots"))
+    )
+    mower = _build_mower(payload, 1, "Timezone Fixture")
+
+    device = DeviceHandler(api=object(), mower=mower, tz=None)
+
+    next_schedule = device.schedules["next_schedule_start"]
+    assert next_schedule is not None
+    assert next_schedule.tzinfo == ZoneInfo(payload["cfg"]["tz"])
 
 
 MQTT_FIXTURES = tuple(fixture_paths("mqtt.json"))


### PR DESCRIPTION
## Summary
Prefer the mower's decoded device timezone for schedule timestamp conversion when no explicit instance timezone is configured, and only fall back to UTC as a last resort.

## Testing
- python3 -m pytest -q tests/test_device_decode.py
- python3 -m pytest -q tests/test_device_decode.py tests/test_api_lifecycle.py tests/test_mqtt_lifecycle.py

## Known limitations
- None beyond the normal timezone data quality provided by the mower payload.

Fixes #996
