### PR TITLE
Add torque control command

### DIFF
--- a/pyworxcloud/__init__.py
+++ b/pyworxcloud/__init__.py
@@ -1044,6 +1044,28 @@ class WorxCloud(dict):
         else:
             raise OfflineError("The device is currently offline, no action was sent.")
 
+    async def set_torque(self, serial_number: str, torque: int) -> None:
+        """Set wheel torque percentage.
+
+        Args:
+            serial_number (str): Serial number of the device
+            torque (int): Wheel torque percentage.
+
+        Raises:
+            OfflineError: Raised if the device is offline.
+        """
+        torque = self._coerce_int(torque, "torque", minimum=-50, maximum=50)
+        mower = self.get_mower(serial_number)
+        if mower["online"]:
+            await self.mqtt.apublish(
+                serial_number if mower["protocol"] == 0 else mower["uuid"],
+                mower["mqtt_topics"]["command_in"],
+                {"tq": torque},
+                mower["protocol"],
+            )
+        else:
+            raise OfflineError("The device is currently offline, no action was sent.")
+
     async def edgecut(self, serial_number: str) -> None:
         """Start an edge cutting task.
 

--- a/tests/test_api_lifecycle.py
+++ b/tests/test_api_lifecycle.py
@@ -605,6 +605,21 @@ def test_set_time_extension_rejects_out_of_range_input_early(monkeypatch) -> Non
         asyncio.run(cloud.set_time_extension("SERIAL-1", 25))
 
 
+def test_set_torque_rejects_out_of_range_input_early(monkeypatch) -> None:
+    """set_torque should validate the percentage before mower lookup."""
+    cloud = WorxCloud("user@example.com", "secret", "worx")
+
+    def _unexpected_lookup(_serial: str) -> dict:
+        raise AssertionError("get_mower should not be called for invalid int input")
+
+    monkeypatch.setattr(cloud, "get_mower", _unexpected_lookup)
+
+    with pytest.raises(ValueError):
+        asyncio.run(cloud.set_torque("SERIAL-1", -51))
+    with pytest.raises(ValueError):
+        asyncio.run(cloud.set_torque("SERIAL-1", 51))
+
+
 def test_set_time_extension_publishes_schedule_payload() -> None:
     """set_time_extension should publish the documented sc.p payload."""
     cloud = WorxCloud("user@example.com", "secret", "worx")
@@ -648,6 +663,54 @@ def test_set_time_extension_publishes_schedule_payload() -> None:
             "serial": "UUID-1",
             "topic": "topic/in",
             "message": {"sc": {"p": 20}},
+            "protocol": 1,
+        }
+    ]
+
+
+def test_set_torque_publishes_torque_payload() -> None:
+    """set_torque should publish the documented tq payload."""
+    cloud = WorxCloud("user@example.com", "secret", "worx")
+    calls: list[dict[str, Any]] = []
+
+    class CapturingMQTT(DummyMQTT):
+        async def apublish(
+            self,
+            serial: str,
+            topic: str,
+            message: Any,
+            protocol: int | None = None,
+        ) -> None:
+            calls.append(
+                {
+                    "serial": serial,
+                    "topic": topic,
+                    "message": message,
+                    "protocol": protocol,
+                }
+            )
+
+    cloud.mqtt = CapturingMQTT()
+    cloud._mowers = [
+        {
+            "name": "Target",
+            "serial_number": "SERIAL-1",
+            "uuid": "UUID-1",
+            "mac_address": "MAC-1",
+            "online": True,
+            "protocol": 1,
+            "mqtt_topics": {"command_in": "topic/in"},
+        }
+    ]
+    cloud._rebuild_mower_indices()
+
+    asyncio.run(cloud.set_torque("SERIAL-1", -13))
+
+    assert calls == [
+        {
+            "serial": "UUID-1",
+            "topic": "topic/in",
+            "message": {"tq": -13},
             "protocol": 1,
         }
     ]


### PR DESCRIPTION
## Summary
- add a dedicated `set_torque(...)` helper instead of relying on raw `send(...)`
- validate torque values before mower lookup and publish the documented `{"tq": value}` payload
- add regression coverage for validation and MQTT publish behavior

## Test strategy
- `python3 -m pytest -q tests/test_api_lifecycle.py`
- `python3 -m py_compile pyworxcloud/__init__.py tests/test_api_lifecycle.py`

## Known limitations
- this only adds the module command surface; entity exposure still needs to be implemented in `landroid_cloud`

## Configuration changes
- none

Fixes #975