### PR TITLE
Skip zero-duration next schedule slots

### DIFF
--- a/pyworxcloud/utils/schedules.py
+++ b/pyworxcloud/utils/schedules.py
@@ -32,7 +32,11 @@ class ScheduleInfo:
 
     def _slots_for_date(self, date: datetime) -> list[dict[str, Any]]:
         day = DAY_MAP[int(date.strftime("%w"))]
-        slots = [slot for slot in self.__slots if slot.get("day") == day]
+        slots = [
+            slot
+            for slot in self.__slots
+            if slot.get("day") == day and int(slot.get("duration_extended", 0)) > 0
+        ]
         return sorted(slots, key=lambda slot: slot.get("start", "00:00"))
 
     def _slot_datetimes(

--- a/tests/test_device_decode.py
+++ b/tests/test_device_decode.py
@@ -300,6 +300,48 @@ def test_protocol0_next_schedule_includes_secondary_same_day_slot(
     assert schedule["next_schedule_start"] == "2026-03-12 12:00:00"
 
 
+def test_next_schedule_skips_zero_duration_slots(monkeypatch) -> None:
+    """Zero-duration slots should not be exposed as the next schedule."""
+    real_datetime = schedules_module.datetime
+
+    class FrozenDateTime:
+        """Minimal datetime shim returning a fixed current time."""
+
+        @staticmethod
+        def now() -> Any:
+            return real_datetime(2026, 3, 12, 10, 30, tzinfo=ZoneInfo("UTC"))
+
+        strptime = staticmethod(real_datetime.strptime)
+
+    monkeypatch.setattr(schedules_module, "datetime", FrozenDateTime)
+
+    schedule = Schedule()
+    schedule["slots"] = [
+        {
+            "day": "thursday",
+            "start": "11:00",
+            "end": "11:00",
+            "duration": 0,
+            "duration_extended": 0,
+            "boundary": False,
+            "source": "protocol1",
+        },
+        {
+            "day": "thursday",
+            "start": "15:00",
+            "end": "15:30",
+            "duration": 30,
+            "duration_extended": 30,
+            "boundary": False,
+            "source": "protocol1",
+        },
+    ]
+
+    schedule.update_progress_and_next("UTC")
+
+    assert schedule["next_schedule_start"] == "2026-03-12 15:00:00"
+
+
 MQTT_FIXTURES = tuple(fixture_paths("mqtt.json"))
 
 


### PR DESCRIPTION
## Summary
- skip zero-duration schedule slots when calculating the next upcoming schedule
- add regression coverage so disabled/empty slots are not exposed as the next mowing start

## Test strategy
- `python3 -m pytest -q tests/test_device_decode.py`
- `python3 -m py_compile pyworxcloud/utils/schedules.py tests/test_device_decode.py`

## Known limitations
- this only changes next-schedule selection; it does not alter schedule payload parsing itself

## Configuration changes
- none