### PR TITLE
Revert zero-duration next schedule change

### DIFF
--- a/pyworxcloud/utils/schedules.py
+++ b/pyworxcloud/utils/schedules.py
@@ -32,11 +32,7 @@ class ScheduleInfo:
 
     def _slots_for_date(self, date: datetime) -> list[dict[str, Any]]:
         day = DAY_MAP[int(date.strftime("%w"))]
-        slots = [
-            slot
-            for slot in self.__slots
-            if slot.get("day") == day and int(slot.get("duration_extended", 0)) > 0
-        ]
+        slots = [slot for slot in self.__slots if slot.get("day") == day]
         return sorted(slots, key=lambda slot: slot.get("start", "00:00"))
 
     def _slot_datetimes(

--- a/tests/test_device_decode.py
+++ b/tests/test_device_decode.py
@@ -340,48 +340,6 @@ def test_devicehandler_maps_rtk_zone_ids_and_current_zone() -> None:
     assert device.zone.index == 2
 
 
-def test_next_schedule_skips_zero_duration_slots(monkeypatch) -> None:
-    """Zero-duration slots should not be exposed as the next schedule."""
-    real_datetime = schedules_module.datetime
-
-    class FrozenDateTime:
-        """Minimal datetime shim returning a fixed current time."""
-
-        @staticmethod
-        def now() -> Any:
-            return real_datetime(2026, 3, 12, 10, 30, tzinfo=ZoneInfo("UTC"))
-
-        strptime = staticmethod(real_datetime.strptime)
-
-    monkeypatch.setattr(schedules_module, "datetime", FrozenDateTime)
-
-    schedule = Schedule()
-    schedule["slots"] = [
-        {
-            "day": "thursday",
-            "start": "11:00",
-            "end": "11:00",
-            "duration": 0,
-            "duration_extended": 0,
-            "boundary": False,
-            "source": "protocol1",
-        },
-        {
-            "day": "thursday",
-            "start": "15:00",
-            "end": "15:30",
-            "duration": 30,
-            "duration_extended": 30,
-            "boundary": False,
-            "source": "protocol1",
-        },
-    ]
-
-    schedule.update_progress_and_next("UTC")
-
-    assert schedule["next_schedule_start"] == "2026-03-12 15:00:00"
-
-
 MQTT_FIXTURES = tuple(fixture_paths("mqtt.json"))
 
 


### PR DESCRIPTION
## Summary
- revert the zero-duration next-schedule filtering from `pyworxcloud`
- keep that behavior change out of the module layer so it can be implemented in `landroid_cloud` instead

## Test strategy
- revert only

## Known limitations
- the corresponding fix will be reintroduced in `landroid_cloud`

## Configuration changes
- none