### PR TITLE
Speed up MQTT shutdown teardown

### DIFF
--- a/pyworxcloud/__init__.py
+++ b/pyworxcloud/__init__.py
@@ -9,6 +9,7 @@ import asyncio
 import json
 import logging
 import sys
+import time
 import warnings
 from datetime import datetime, timedelta, timezone
 from random import randint
@@ -282,13 +283,25 @@ class WorxCloud(dict):
         # Disconnect MQTT connection
         try:
             if self.mqtt is not None:
+                started = time.perf_counter()
                 await self.mqtt.adisconnect()
+                logger.debug(
+                    "MQTT adisconnect completed in %.3fs",
+                    time.perf_counter() - started,
+                )
+                started = time.perf_counter()
                 await self.mqtt.ashutdown()
+                logger.debug(
+                    "MQTT ashutdown completed in %.3fs",
+                    time.perf_counter() - started,
+                )
         except Exception as err:
             logger.debug("Could not disconnect MQTT cleanly: %s", err)
         finally:
             self.mqtt = None
+            started = time.perf_counter()
             await self._api.close()
+            logger.debug("API close completed in %.3fs", time.perf_counter() - started)
 
     async def connect(
         self,

--- a/pyworxcloud/utils/mqtt.py
+++ b/pyworxcloud/utils/mqtt.py
@@ -22,8 +22,9 @@ import itertools
 import json
 import random
 import threading
+import time
 import urllib.parse
-from concurrent.futures import Future
+from concurrent.futures import Future, TimeoutError as FutureTimeoutError
 from datetime import datetime, timezone
 from logging import Logger
 from typing import Any, Callable, Optional
@@ -39,6 +40,7 @@ from .landroid_class import LDict
 
 QOS_FLAG = awscrt.mqtt.QoS.AT_LEAST_ONCE
 DEFAULT_RESPONSE_TIMEOUT = 30.0
+DEFAULT_SHUTDOWN_TIMEOUT = 5.0
 
 
 class MQTTMsgType(LDict):
@@ -151,6 +153,7 @@ class MQTT(LDict):
             f"{self._brandprefix}/USER/{self._user_id}/homeassistant/{self._uuid}"
         )
         self._shutdown_event = False
+        self._shutdown_timeout = DEFAULT_SHUTDOWN_TIMEOUT
 
         # Create event loop group and connection
         self._event_loop_group = awscrt.io.EventLoopGroup(1)
@@ -372,9 +375,12 @@ class MQTT(LDict):
 
             try:
                 if self._is_connected:
+                    started = time.perf_counter()
                     disconnect_future = client.disconnect()
                     disconnect_future.result()
-                    logger.debug("MQTT disconnected")
+                    logger.debug(
+                        "MQTT disconnected in %.3fs", time.perf_counter() - started
+                    )
             except Exception as err:  # pragma: no cover - defensive
                 logger.debug("MQTT disconnect raised during teardown: %s", err)
             finally:
@@ -388,6 +394,7 @@ class MQTT(LDict):
 
     def shutdown(self) -> None:
         """Release background AWS CRT resources."""
+        logger = self._log.getChild("MQTT_Shutdown")
         with self._lifecycle_lock:
             if self._shutdown_event:
                 return
@@ -409,17 +416,38 @@ class MQTT(LDict):
         # Disconnect after detaching internals, so concurrent calls see teardown state.
         if client is not None and was_connected:
             try:
+                started = time.perf_counter()
                 disconnect_future = client.disconnect()
-                disconnect_future.result()
+                disconnect_future.result(
+                    timeout=getattr(
+                        self, "_shutdown_timeout", DEFAULT_SHUTDOWN_TIMEOUT
+                    )
+                )
+                logger.debug(
+                    "Shutdown disconnect completed in %.3fs",
+                    time.perf_counter() - started,
+                )
+            except FutureTimeoutError:  # pragma: no cover - defensive
+                logger.debug(
+                    "Shutdown disconnect timed out after %.3fs",
+                    time.perf_counter() - started,
+                )
             except Exception:  # pragma: no cover - defensive
-                pass
-
-        if host_resolver is not None and hasattr(host_resolver, "shutdown_event"):
-            host_resolver.shutdown_event.wait(5)
-        if client_bootstrap is not None and hasattr(client_bootstrap, "shutdown_event"):
-            client_bootstrap.shutdown_event.wait(5)
-        if event_loop_group is not None and hasattr(event_loop_group, "shutdown_event"):
-            event_loop_group.shutdown_event.wait(5)
+                logger.debug(
+                    "Shutdown disconnect raised after %.3fs",
+                    time.perf_counter() - started,
+                    exc_info=True,
+                )
+        for name, resource in (
+            ("host_resolver", host_resolver),
+            ("client_bootstrap", client_bootstrap),
+            ("event_loop_group", event_loop_group),
+        ):
+            if resource is not None:
+                # Rollback point: if repeated connect/disconnect cycles start leaking
+                # native AWS CRT resources again, restore the old shutdown_event.wait()
+                # logic here and re-enable the corresponding lifecycle wait test.
+                logger.debug("Detached %s without waiting for shutdown_event", name)
 
     async def ashutdown(self) -> None:
         """Async shutdown wrapper."""

--- a/tests/test_mqtt_lifecycle.py
+++ b/tests/test_mqtt_lifecycle.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 import logging
 import threading
+from concurrent.futures import TimeoutError as FutureTimeoutError
 from typing import Any
-
 from pyworxcloud.utils.mqtt import MQTT
 
 
@@ -16,18 +16,26 @@ class _ImmediateFuture:
         return None
 
 
+class _TimeoutFuture:
+    """Future stub that always times out."""
+
+    def result(self, timeout: float | None = None) -> None:
+        raise FutureTimeoutError(f"timed out after {timeout}")
+
+
 class _ClientStub:
     """Client stub that records disconnect attempts."""
 
     def __init__(self, should_raise: bool = False) -> None:
         self.disconnect_calls = 0
         self.should_raise = should_raise
+        self.future: Any = _ImmediateFuture()
 
     def disconnect(self) -> _ImmediateFuture:
         self.disconnect_calls += 1
         if self.should_raise:
             raise RuntimeError("disconnect failed")
-        return _ImmediateFuture()
+        return self.future
 
 
 class _ShutdownEventStub:
@@ -57,6 +65,7 @@ def _build_mqtt_lifecycle_fixture(
     mqtt._shutdown_event = False
     mqtt._is_connected = connected
     mqtt._connection_future = object()
+    mqtt._shutdown_timeout = 5.0
     mqtt._topic = ["topic/out"]
     mqtt.client = client
     mqtt._host_resolver = _ShutdownResourceStub()
@@ -115,3 +124,32 @@ def test_shutdown_skips_second_disconnect_after_prior_disconnect() -> None:
     mqtt.shutdown()
 
     assert client.disconnect_calls == 1
+
+
+def test_shutdown_does_not_wait_for_resource_shutdown_events() -> None:
+    """Shutdown should detach CRT resources without blocking on shutdown events."""
+    client = _ClientStub()
+    mqtt = _build_mqtt_lifecycle_fixture(client=client)
+    host_resolver = mqtt._host_resolver
+    client_bootstrap = mqtt._client_bootstrap
+    event_loop_group = mqtt._event_loop_group
+
+    mqtt.shutdown()
+
+    assert (
+        host_resolver.shutdown_event.wait_calls,
+        client_bootstrap.shutdown_event.wait_calls,
+        event_loop_group.shutdown_event.wait_calls,
+    ) == (0, 0, 0)
+
+
+def test_shutdown_swallows_disconnect_future_timeout() -> None:
+    """Shutdown should not block indefinitely on disconnect futures."""
+    client = _ClientStub()
+    client.future = _TimeoutFuture()
+    mqtt = _build_mqtt_lifecycle_fixture(client=client)
+
+    mqtt.shutdown()
+
+    assert client.disconnect_calls == 1
+    assert mqtt._shutdown_event is True


### PR DESCRIPTION
## Summary
Reduce shutdown latency by avoiding blocking waits on AWS CRT `shutdown_event` objects during MQTT teardown, while keeping explicit disconnect/shutdown calls and adding timing visibility around disconnect, CRT teardown, and API close.

## Changes
- stop waiting on AWS CRT `shutdown_event` objects during `MQTT.shutdown()`
- keep explicit MQTT disconnect and CRT detach calls in place
- add teardown timing logs for MQTT disconnect, MQTT shutdown, and API close
- add lifecycle regression coverage for the non-blocking shutdown path
- leave an inline rollback note next to the shutdown code path

## Testing
- `pytest tests/test_mqtt_lifecycle.py tests/test_api_lifecycle.py -q`
- live connect/disconnect measurement against `.env` credentials

## Notes
- Live measurement dropped total disconnect time from about `5s` to about `0.002s` in the current environment.
- Rollback point: restore the old `shutdown_event.wait(...)` logic in `pyworxcloud/utils/mqtt.py` if repeated connect/disconnect cycles show native AWS CRT resource leaks or unstable teardown behaviour.
