### PR TITLE
Fix timezone-aware updated timestamp fallback

### DIFF
--- a/pyworxcloud/utils/devices.py
+++ b/pyworxcloud/utils/devices.py
@@ -6,6 +6,7 @@ import json
 import logging
 from datetime import datetime
 from typing import Any
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from ..const import UNWANTED_ATTRIBS
 from ..exceptions import APIException, InvalidDataDecodeException
@@ -211,12 +212,9 @@ class DeviceHandler(LDict):
             except (TypeError, ValueError):
                 invalid_data = True
 
-        self.updated = self._determine_updated_at(cfg_payload, dat_payload)
-
-        effective_timezone = (
-            self._tz
-            if not isinstance(self._tz, type(None))
-            else self.time_zone if self.time_zone is not None else "UTC"
+        effective_timezone = self._resolve_effective_timezone(cfg_payload)
+        self.updated = self._determine_updated_at(
+            cfg_payload, dat_payload, effective_timezone
         )
 
         self.schedules.update_progress_and_next(tz=effective_timezone)
@@ -373,18 +371,9 @@ class DeviceHandler(LDict):
         self,
         cfg_payload: dict[str, Any] | None,
         dat_payload: dict[str, Any] | None,
+        effective_timezone: str,
     ) -> datetime:
         """Pick the most accurate timestamp available."""
-        if isinstance(cfg_payload, dict) and "dt" in cfg_payload:
-            dt_split = cfg_payload["dt"].split("/")
-            time_value = cfg_payload.get("tm", "00:00:00")
-            try:
-                return datetime.fromisoformat(
-                    f"{dt_split[2]}-{dt_split[1]}-{dt_split[0]} {time_value}"
-                )
-            except ValueError:
-                pass
-
         if isinstance(dat_payload, dict) and "tm" in dat_payload:
             tm_value = dat_payload["tm"]
             if isinstance(tm_value, str) and tm_value.endswith("Z"):
@@ -394,7 +383,47 @@ class DeviceHandler(LDict):
             except ValueError:
                 pass
 
+        if isinstance(cfg_payload, dict) and "dt" in cfg_payload:
+            dt_split = cfg_payload["dt"].split("/")
+            time_value = cfg_payload.get("tm", "00:00:00")
+            try:
+                timezone_info = ZoneInfo(effective_timezone)
+                return datetime.fromisoformat(
+                    f"{dt_split[2]}-{dt_split[1]}-{dt_split[0]} {time_value}"
+                ).replace(tzinfo=timezone_info)
+            except ValueError:
+                pass
+            except ZoneInfoNotFoundError:
+                pass
+
         return datetime.now()
+
+    @staticmethod
+    def _normalize_timezone_name(candidate: Any) -> str | None:
+        """Return a valid timezone key or ``None`` for invalid inputs."""
+        if not isinstance(candidate, str):
+            return None
+        timezone_name = candidate.strip()
+        if not timezone_name:
+            return None
+        try:
+            ZoneInfo(timezone_name)
+        except ZoneInfoNotFoundError:
+            return None
+        return timezone_name
+
+    def _resolve_effective_timezone(self, cfg_payload: dict[str, Any] | None) -> str:
+        """Resolve the best available timezone for schedule and cfg timestamps."""
+        for candidate in (
+            self._tz,
+            cfg_payload.get("tz") if isinstance(cfg_payload, dict) else None,
+            self.time_zone,
+            "UTC",
+        ):
+            timezone_name = self._normalize_timezone_name(candidate)
+            if timezone_name is not None:
+                return timezone_name
+        return "UTC"
 
     def update_attribute(self, device: str, attr: str, key: str, value: Any) -> None:
         """Used as callback to update value."""

--- a/tests/test_device_decode.py
+++ b/tests/test_device_decode.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 from typing import Any, Sequence, Tuple
+from datetime import datetime
 from zoneinfo import ZoneInfo
 
 import pytest
@@ -179,6 +180,63 @@ def test_devicehandler_updates_battery_cycle_current_from_live_nr() -> None:
         "reset_at": 0,
         "reset_time": None,
     }
+
+
+def test_devicehandler_prefers_dat_tm_over_cfg_date_time_for_updated() -> None:
+    """UTC dat.tm should win over cfg date/time when both are present."""
+    payload = {
+        "cfg": {
+            "id": 1,
+            "sn": "SERIAL-UPDATED",
+            "rd": 0,
+            "sc": {"d": [], "dd": False},
+            "tm": "21:30:00",
+            "dt": "12/03/2026",
+            "tz": "Australia/Perth",
+        },
+        "dat": {
+            "uuid": "UUID-UPDATED",
+            "mac": "AA:BB:CC:DD:EE:FF",
+            "conn": "online",
+            "ls": 1,
+            "le": 0,
+            "tm": "2026-03-12T13:30:00.000Z",
+            "rain": {"s": 0, "cnt": 0},
+        },
+    }
+    mower = _build_mower(payload, 0, "Updated Fixture")
+
+    device = DeviceHandler(api=object(), mower=mower, tz="UTC")
+
+    assert device.updated == datetime.fromisoformat("2026-03-12T13:30:00+00:00")
+
+
+def test_devicehandler_falls_back_to_cfg_date_time_when_dat_tm_is_missing() -> None:
+    """cfg date/time should still be used when dat.tm is unavailable."""
+    payload = {
+        "cfg": {
+            "id": 1,
+            "sn": "SERIAL-CFG-UPDATED",
+            "rd": 0,
+            "sc": {"d": [], "dd": False},
+            "tm": "12:00:00",
+            "dt": "11/03/2026",
+            "tz": "Australia/Perth",
+        },
+        "dat": {
+            "uuid": "UUID-CFG-UPDATED",
+            "mac": "AA:BB:CC:DD:EE:FF",
+            "conn": "online",
+            "ls": 1,
+            "le": 0,
+            "rain": {"s": 0, "cnt": 0},
+        },
+    }
+    mower = _build_mower(payload, 0, "CFG Updated Fixture")
+
+    device = DeviceHandler(api=object(), mower=mower, tz=None)
+
+    assert device.updated == datetime.fromisoformat("2026-03-11T12:00:00+08:00")
 
 
 def test_devicehandler_uses_device_timezone_when_instance_timezone_is_missing() -> None:


### PR DESCRIPTION
Summary
Keep `updated` stable by preferring `dat.tm` when present and making the `cfg.dt`/`cfg.tm` fallback timezone-aware instead of returning a naive datetime.

Changes
- prefer `dat.tm` over `cfg.dt`/`cfg.tm` when both timestamps are present
- resolve the effective timezone from the client override, payload timezone, mower timezone, then UTC
- attach the resolved timezone to the `cfg.dt`/`cfg.tm` fallback timestamp
- add regression coverage for both UTC `dat.tm` and timezone-aware `cfg.dt`/`cfg.tm` fallback handling

Testing
- `pytest tests/test_device_decode.py -q`
- live check against `.env` credentials confirmed `2026-03-12T23:24:13+08:00` maps to `2026-03-12T16:24:13+01:00` in Copenhagen

Notes
- This keeps the existing schedule timezone resolution aligned with the timestamp fallback path, so `updated` no longer appears to jump into the future when only `cfg.dt`/`cfg.tm` is available.