### PR TITLE
Resubscribe on MQTT connection resume

### DIFF
--- a/pyworxcloud/utils/mqtt.py
+++ b/pyworxcloud/utils/mqtt.py
@@ -206,11 +206,15 @@ class MQTT(LDict):
             f"Connection resumed. return_code: {return_code}, session_present: {session_present}"
         )
 
-        if (
-            return_code == awscrt.mqtt.ConnectReturnCode.ACCEPTED
-            and not session_present
-        ):
-            logger.debug("Session did not persist. Resubscribing to existing topics...")
+        if return_code == awscrt.mqtt.ConnectReturnCode.ACCEPTED:
+            if session_present:
+                logger.debug(
+                    "Session resumed. Resubscribing to existing topics defensively..."
+                )
+            else:
+                logger.debug(
+                    "Session did not persist. Resubscribing to existing topics..."
+                )
             for topic in self._topic:
                 logger.debug(f"Resubscribing to '{topic}'")
                 self.subscribe(topic, False)

--- a/tests/test_mqtt_lifecycle.py
+++ b/tests/test_mqtt_lifecycle.py
@@ -7,6 +7,8 @@ import threading
 from concurrent.futures import TimeoutError as FutureTimeoutError
 from typing import Any
 
+import awscrt.mqtt
+
 from pyworxcloud.utils.mqtt import MQTT
 
 
@@ -154,3 +156,48 @@ def test_shutdown_swallows_disconnect_future_timeout() -> None:
 
     assert client.disconnect_calls == 1
     assert mqtt._shutdown_event is True
+
+
+def test_connection_resumed_resubscribes_even_when_session_persists() -> None:
+    """Resume should defensively resubscribe even when broker reports session_present."""
+    mqtt = _build_mqtt_lifecycle_fixture(connected=False, client=_ClientStub())
+    mqtt._topic = ["topic/a", "topic/b"]
+    subscribe_calls: list[tuple[str, bool]] = []
+    events: list[bool] = []
+    mqtt.subscribe = lambda topic, append=True: subscribe_calls.append((topic, append))
+    mqtt._events = type(
+        "_Events",
+        (),
+        {"call": staticmethod(lambda _event, state: events.append(state))},
+    )()
+
+    mqtt._on_connection_resumed(
+        None,
+        awscrt.mqtt.ConnectReturnCode.ACCEPTED,
+        True,
+    )
+
+    assert mqtt._is_connected is True
+    assert subscribe_calls == [("topic/a", False), ("topic/b", False)]
+    assert events == [True]
+
+
+def test_connection_resumed_resubscribes_when_session_is_not_present() -> None:
+    """Resume should still resubscribe when broker reports a lost session."""
+    mqtt = _build_mqtt_lifecycle_fixture(connected=False, client=_ClientStub())
+    mqtt._topic = ["topic/out"]
+    subscribe_calls: list[tuple[str, bool]] = []
+    mqtt.subscribe = lambda topic, append=True: subscribe_calls.append((topic, append))
+    mqtt._events = type(
+        "_Events",
+        (),
+        {"call": staticmethod(lambda *_args, **_kwargs: None)},
+    )()
+
+    mqtt._on_connection_resumed(
+        None,
+        awscrt.mqtt.ConnectReturnCode.ACCEPTED,
+        False,
+    )
+
+    assert subscribe_calls == [("topic/out", False)]


### PR DESCRIPTION
Summary
Defensively resubscribe to all tracked MQTT topics whenever the AWS IoT connection resumes, even when the broker reports that the previous session is still present.

Changes
- resubscribe to all stored topics on every accepted connection resume
- keep the existing logging but distinguish between persistent and non-persistent session resumes
- add regression coverage for both `session_present=True` and `session_present=False` resume flows

Testing
- `pytest tests/test_mqtt_lifecycle.py -q`
- `python3 -m compileall pyworxcloud/utils/mqtt.py tests/test_mqtt_lifecycle.py`

Notes
- This is intentionally defensive because the reconnect path can report `session_present=True` while live topic updates still stop arriving after a hangup.