### PR TITLE
Remove dashboard auto polling

### DIFF
--- a/test_dashboard.py
+++ b/test_dashboard.py
@@ -252,10 +252,8 @@ def _render_device(device: DeviceHandler, selected: str, event_text: str) -> Non
 
 
 async def _run_dashboard(cloud: WorxCloud) -> None:
-    poll_interval = 60.0
     event_text = "no events yet"
     selected = await _choose_mower(cloud)
-    last_poll = 0.0
     running = True
     input_task: asyncio.Task[str] | None = None
     input_in_progress = False
@@ -289,7 +287,6 @@ async def _run_dashboard(cloud: WorxCloud) -> None:
 
     try:
         while running:
-            now = asyncio.get_running_loop().time()
             device = cloud.devices[selected]
             serial = device.serial_number
 
@@ -302,13 +299,6 @@ async def _run_dashboard(cloud: WorxCloud) -> None:
             if input_task is None:
                 input_task = asyncio.create_task(_prompt_input("\ncmd> "))
                 input_in_progress = True
-
-            if now - last_poll >= poll_interval:
-                try:
-                    await cloud.update(serial)
-                except Exception as err:  # pragma: no cover - interactive helper
-                    event_text = f"Poll error: {type(err).__name__}: {err}"
-                last_poll = now
 
             if input_task is None or not input_task.done():
                 await asyncio.sleep(0.2)

--- a/test_dashboard_gui.py
+++ b/test_dashboard_gui.py
@@ -200,7 +200,6 @@ class CloudWorker:
         self._thread = threading.Thread(target=self._run_loop, daemon=True)
         self._thread.start()
         self._cloud: WorxCloud | None = None
-        self._poll_task: asyncio.Task | None = None
         self._selected_name: str | None = None
         self._log_level = _configure_logging()
         self._update_event = asyncio.Event()
@@ -281,26 +280,8 @@ class CloudWorker:
         if mowers:
             self._selected_name = mowers[0]["name"]
         self._emit("connected", mowers=mowers, selected=self._selected_name)
-        self._poll_task = asyncio.create_task(self._poll_loop())
-
-    async def _poll_loop(self) -> None:
-        while self._cloud is not None:
-            await asyncio.sleep(60)
-            if self._cloud is None or not self._selected_name:
-                continue
-            device = self._cloud.devices.get(self._selected_name)
-            if device is None:
-                continue
-            with contextlib.suppress(Exception):
-                await self._cloud.update(device.serial_number)
 
     async def disconnect(self) -> None:
-        if self._poll_task is not None:
-            self._poll_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await self._poll_task
-            self._poll_task = None
-
         if self._cloud is not None:
             with contextlib.suppress(Exception):
                 await self._cloud.disconnect()


### PR DESCRIPTION
Summary
Remove the periodic one-minute API polling from the manual dashboards so live testing only reacts to MQTT traffic and explicit user-triggered refreshes.

Changes
- remove the 60-second auto-poll loop from the terminal dashboard
- remove the background poll task from the GUI dashboard worker
- keep manual refresh actions unchanged

Testing
- `python3 -m compileall test_dashboard.py test_dashboard_gui.py`

Notes
- This avoids unnecessary API refreshes during live debugging and prevents the dashboards from perturbing MQTT-driven timestamp behavior.