### PR TITLE
Fix party mode call for RTK/Vision devices

### DIFF
--- a/pyworxcloud/__init__.py
+++ b/pyworxcloud/__init__.py
@@ -1187,7 +1187,9 @@ class WorxCloud(dict):
                     await self.mqtt.apublish(
                         serial_number if mower["protocol"] == 0 else mower["uuid"],
                         mower["mqtt_topics"]["command_in"],
-                        {"sc": {"enabled": 0}} if state else {"sc": {"enabled": 1}},
+                        {"cmd": 0, "sc": {"enabled": 0}}
+                        if state
+                        else {"cmd": 0, "sc": {"enabled": 1}},
                         mower["protocol"],
                     )
             elif not device.capabilities.check(DeviceCapability.PARTY_MODE):

--- a/tests/test_api_lifecycle.py
+++ b/tests/test_api_lifecycle.py
@@ -2566,3 +2566,63 @@ def test_set_pause_mode_warns_and_calls_party_mode(monkeypatch) -> None:
         "set_pause_mode() is deprecated" in str(item.message) for item in captured
     )
     assert calls[0]["message"] == {"sc": {"m": 2, "distm": 0}}
+
+
+def test_set_party_mode_protocol1_includes_cmd0(monkeypatch) -> None:
+    """Protocol 1 party mode writes should include the cmd=0 scheduler envelope."""
+    cloud = WorxCloud("user@example.com", "secret", "worx")
+    calls: list[dict[str, Any]] = []
+
+    class CapturingMQTT(DummyMQTT):
+        async def apublish(
+            self,
+            serial: str,
+            topic: str,
+            message: Any,
+            protocol: int | None = None,
+        ) -> None:
+            calls.append(
+                {
+                    "serial": serial,
+                    "topic": topic,
+                    "message": message,
+                    "protocol": protocol,
+                }
+            )
+
+    class DummyCapabilities:
+        def check(self, _capability: Any) -> bool:
+            return True
+
+    class StubDeviceHandler:
+        def __init__(self, *_args: Any, **_kwargs: Any) -> None:
+            self.capabilities = DummyCapabilities()
+
+    monkeypatch.setattr("pyworxcloud.DeviceHandler", StubDeviceHandler)
+    cloud.mqtt = CapturingMQTT()
+    cloud._mowers = [
+        {
+            "name": "Proto1",
+            "serial_number": "SERIAL-1",
+            "uuid": "UUID-1",
+            "mac_address": "MAC-1",
+            "online": True,
+            "protocol": 1,
+            "mqtt_topics": {"command_in": "topic/p1"},
+            "last_status": {
+                "payload": {"cfg": {"sc": {"enabled": 0, "paused": 0}}, "dat": {}}
+            },
+        }
+    ]
+    cloud._rebuild_mower_indices()
+
+    asyncio.run(cloud.set_party_mode("SERIAL-1", False))
+
+    assert calls == [
+        {
+            "serial": "UUID-1",
+            "topic": "topic/p1",
+            "message": {"cmd": 0, "sc": {"enabled": 1}},
+            "protocol": 1,
+        }
+    ]


### PR DESCRIPTION
## Summary
Fix the protocol 1 party mode MQTT envelope for RTK/Vision devices so the command is accepted by the mower.

## Changes
Update `set_party_mode()` for protocol 1 devices to include `cmd: 0` alongside the `sc` payload. Add regression coverage that verifies protocol 1 party mode writes include the scheduler envelope while keeping protocol 0 behavior unchanged.

## Testing
- `poetry run ruff format pyworxcloud/__init__.py tests/test_api_lifecycle.py`
- `poetry run ruff check pyworxcloud/__init__.py tests/test_api_lifecycle.py`
- `poetry run pytest -q tests/test_api_lifecycle.py -k "set_pause_mode_warns_and_calls_party_mode or set_party_mode_protocol1_includes_cmd0"`

## Notes
Proposed semver label: `patch`.
This PR was verified manually against a protocol 1 RTK/Vision device before opening.
