### PR TITLE
Wrap torque in cfg for protocol 1 devices

### DIFF
--- a/pyworxcloud/__init__.py
+++ b/pyworxcloud/__init__.py
@@ -1797,12 +1797,21 @@ class WorxCloud(dict):
         torque = self._coerce_int(torque, "torque", minimum=-50, maximum=50)
         mower = self.get_mower(serial_number)
         if mower["online"]:
-            await self.mqtt.apublish(
-                serial_number if mower["protocol"] == 0 else mower["uuid"],
-                mower["mqtt_topics"]["command_in"],
-                {"tq": torque},
-                mower["protocol"],
-            )
+            if mower["protocol"] == 0:
+                await self.mqtt.apublish(
+                    serial_number,
+                    mower["mqtt_topics"]["command_in"],
+                    {"tq": torque},
+                    mower["protocol"],
+                )
+            else:
+                # Protocol 1 requires tq to be wrapped in cfg
+                await self.mqtt.apublish(
+                    mower["uuid"],
+                    mower["mqtt_topics"]["command_in"],
+                    {"cfg": {"tq": torque}},
+                    mower["protocol"],
+                )
         else:
             raise OfflineError("The device is currently offline, no action was sent.")
 

--- a/tests/test_api_lifecycle.py
+++ b/tests/test_api_lifecycle.py
@@ -2506,7 +2506,7 @@ def test_set_torque_publishes_torque_payload() -> None:
         {
             "serial": "UUID-1",
             "topic": "topic/in",
-            "message": {"tq": -13},
+            "message": {"cfg": {"tq": -13}},
             "protocol": 1,
         }
     ]


### PR DESCRIPTION
## Description

Torque settings were not being applied to Vision mowers (protocol 1) because the `tq` field needs to be wrapped inside a `cfg` object for protocol 1, similar to how schedule updates work.

## Problem

From the issue:
- Sending `{"tq": -22}` to a Vision mower (protocol 1) results in `tq: 0` - the value is ignored
- The same command works correctly for M600 (protocol 0)

## Solution

For protocol 1 devices, wrap the torque value in a `cfg` object:
- Protocol 0: `{"tq": torque}`
- Protocol 1: `{"cfg": {"tq": torque}}`

This matches how other configuration updates (like schedules) work for protocol 1.

## Fixes

https://github.com/MTrab/landroid_cloud/issues/1209