### PR TITLE
Fix Content-Type to application/json for POST requests

### DIFF
--- a/pyworxcloud/utils/requests.py
+++ b/pyworxcloud/utils/requests.py
@@ -37,7 +37,7 @@ def HEADERS(access_token: str | None = None) -> dict:
     }
 
     if isinstance(access_token, type(None)):
-        head.update({"Content-Type": "application/x-www-form-urlencoded"})
+        head.update({"Content-Type": "application/json"})
     else:
         head.update({"Authorization": f"Bearer {access_token}"})
 
@@ -104,7 +104,7 @@ async def APOST(
     owns_session = session is None
     client = session or await create_async_session()
     try:
-        async with client.post(URL, data=REQUEST_BODY, headers=HEADER) as resp:
+        async with client.post(URL, json=REQUEST_BODY, headers=HEADER) as resp:
             if resp.status >= 400:
                 _raise_http_status(resp.status, Exception(f"HTTP {resp.status}"))
             return await resp.json()


### PR DESCRIPTION
## Summary
Changes the Content-Type from application/x-www-form-urlencoded to application/json and uses json= parameter in aiohttp POST requests.

## Changes
- Changed HEADERS function to set Content-Type to application/json
- Changed APOST function to use json= instead of data= in aiohttp post call

## Testing
- ruff format and ruff check passed

## Notes
- This fix ensures compatibility with APIs expecting JSON content type