### PR TITLE
Add awsiotsdk 1.29.0 MQTT connect compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ readme = "README.md"
 python = "^3.9"
 urllib3 = ">=1.26.5"
 requests = "^2.32.0"
-awsiotsdk = "1.28.2"
+awsiotsdk = ">=1.28.2,<1.30.0"
 aiohttp = "^3.11.0"
 tzdata = ">=2024.1"
 

--- a/pyworxcloud/utils/mqtt.py
+++ b/pyworxcloud/utils/mqtt.py
@@ -43,6 +43,65 @@ QOS_FLAG = awscrt.mqtt.QoS.AT_LEAST_ONCE
 DEFAULT_RESPONSE_TIMEOUT = 30.0
 DEFAULT_DISCONNECT_TIMEOUT = 0.5
 DEFAULT_SHUTDOWN_TIMEOUT = 0.25
+AWSCRT_CONNECT_ARG_MISMATCH = "function takes exactly 18 arguments (17 given)"
+
+
+def _is_awscrt_connect_arg_mismatch(err: TypeError) -> bool:
+    """Return whether AWS CRT hit the known 0.32.x connect arg mismatch."""
+    return AWSCRT_CONNECT_ARG_MISMATCH in str(err)
+
+
+def _legacy_connect_without_metrics(client: Any) -> Future:
+    """Call the pre-0.32 AWS CRT connect signature for mixed installations."""
+    import _awscrt  # pylint: disable=import-outside-toplevel
+    import awscrt.exceptions  # pylint: disable=import-outside-toplevel
+
+    future = Future()
+
+    def on_connect(error_code, return_code, session_present):
+        if return_code:
+            future.set_exception(Exception(awscrt.mqtt.ConnectReturnCode(return_code)))
+        elif error_code:
+            future.set_exception(awscrt.exceptions.from_code(error_code))
+        else:
+            future.set_result(dict(session_present=session_present))
+
+    _awscrt.mqtt_client_connection_connect(
+        client._binding,
+        client.client_id,
+        client.host_name,
+        client.port,
+        client.socket_options,
+        client.client.tls_ctx,
+        client.reconnect_min_timeout_secs,
+        client.reconnect_max_timeout_secs,
+        client.keep_alive_secs,
+        client.ping_timeout_ms,
+        client.protocol_operation_timeout_ms,
+        client.will,
+        client.username,
+        client.password,
+        client.clean_session,
+        on_connect,
+        client.proxy_options,
+    )
+
+    return future
+
+
+def _connect_with_awscrt_compat(client: Any, logger: Logger) -> Future:
+    """Connect while tolerating the awscrt 0.32.x mixed-installation bug."""
+    try:
+        return client.connect()
+    except TypeError as err:
+        if not _is_awscrt_connect_arg_mismatch(err):
+            raise
+
+        logger.warning(
+            "AWS CRT connect hit the known 17/18-argument mismatch; "
+            "retrying with legacy compatibility path"
+        )
+        return _legacy_connect_without_metrics(client)
 
 
 class MQTTMsgType(LDict):
@@ -438,7 +497,7 @@ class MQTT(LDict):
         self._get_ready_event().clear()
         try:
             # Create a connection future
-            self._connection_future = client.connect()
+            self._connection_future = _connect_with_awscrt_compat(client, self._log)
 
             # Wait for connection to complete
             self._connection_future.result()

--- a/tests/test_mqtt_lifecycle.py
+++ b/tests/test_mqtt_lifecycle.py
@@ -8,8 +8,9 @@ from concurrent.futures import TimeoutError as FutureTimeoutError
 from typing import Any
 
 import awscrt.mqtt
+import pytest
 
-from pyworxcloud.utils.mqtt import MQTT
+from pyworxcloud.utils.mqtt import MQTT, _connect_with_awscrt_compat
 
 
 class _ImmediateFuture:
@@ -39,6 +40,20 @@ class _ClientStub:
         if self.should_raise:
             raise RuntimeError("disconnect failed")
         return self.future
+
+
+class _ConnectMismatchClientStub:
+    """Client stub that reproduces the awscrt 17/18-arg connect mismatch."""
+
+    def connect(self) -> None:
+        raise TypeError("function takes exactly 18 arguments (17 given)")
+
+
+class _ConnectTypeErrorClientStub:
+    """Client stub that raises an unrelated TypeError."""
+
+    def connect(self) -> None:
+        raise TypeError("some other type error")
 
 
 class _ShutdownEventStub:
@@ -169,6 +184,39 @@ def test_shutdown_swallows_disconnect_future_timeout() -> None:
 
     assert client.disconnect_calls == 1
     assert mqtt._shutdown_event is True
+
+
+def test_connect_with_awscrt_compat_retries_known_arg_mismatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Known mixed awscrt installs should use the legacy compatibility path."""
+    fallback_future = _ImmediateFuture()
+    fallback_calls: list[Any] = []
+
+    def _legacy(client: Any) -> _ImmediateFuture:
+        fallback_calls.append(client)
+        return fallback_future
+
+    monkeypatch.setattr(
+        "pyworxcloud.utils.mqtt._legacy_connect_without_metrics", _legacy
+    )
+
+    result = _connect_with_awscrt_compat(
+        _ConnectMismatchClientStub(),
+        logging.getLogger("test"),
+    )
+
+    assert result is fallback_future
+    assert len(fallback_calls) == 1
+
+
+def test_connect_with_awscrt_compat_preserves_unrelated_type_errors() -> None:
+    """Only the known awscrt mismatch should trigger the compatibility path."""
+    with pytest.raises(TypeError, match="some other type error"):
+        _connect_with_awscrt_compat(
+            _ConnectTypeErrorClientStub(),
+            logging.getLogger("test"),
+        )
 
 
 def test_connection_resumed_resubscribes_even_when_session_persists() -> None:


### PR DESCRIPTION
## Summary
Add compatibility for `awsiotsdk` 1.29.0 while keeping support for 1.28.2 during the transition period.

## Changes
Broaden the `awsiotsdk` dependency range to allow both 1.28.2 and 1.29.0. Add a targeted MQTT connect compatibility path that retries with the legacy AWS CRT connect signature when the known 17/18-argument mismatch occurs in mixed `awscrt` installations.

Add regression tests covering the compatibility fallback and preserving normal error handling for unrelated `TypeError` cases.

## Testing
`git status --short --branch`
`ruff format pyworxcloud/utils/mqtt.py tests/test_mqtt_lifecycle.py pyproject.toml`
`ruff check pyworxcloud/utils/mqtt.py tests/test_mqtt_lifecycle.py`
`PYTHONPATH=/home/vscode/pyworxcloud /tmp/pyworx128/bin/pytest tests/test_mqtt_lifecycle.py tests/test_mqtt_runtime.py -q`
`PYTHONPATH=/home/vscode/pyworxcloud /tmp/pyworx129/bin/pytest tests/test_mqtt_lifecycle.py tests/test_mqtt_runtime.py -q`
`PYTHONPATH=/home/vscode/pyworxcloud /tmp/pyworx129/bin/pytest tests -q`

## Notes
Proposed semver label: `patch`.
Label not set yet pending explicit approval.
