### PR TITLE
Fix ONE_TIME_SCHEDULE and EDGE_CUT capability detection for Vision mo…

### DIFF
--- a/pyworxcloud/utils/capability.py
+++ b/pyworxcloud/utils/capability.py
@@ -78,14 +78,12 @@ class Capability:
                 if "distm" in cfg["sc"] or "enabled" in cfg["sc"]:
                     self.add(DeviceCapability.PARTY_MODE)
 
+            if "sc" in dat:
+                if "ots" in dat["sc"] or "once" in dat["sc"]:
+                    self.add(DeviceCapability.ONE_TIME_SCHEDULE)
+                    self.add(DeviceCapability.EDGE_CUT)
         except TypeError:
             pass
-
-        if not self.check(DeviceCapability.ONE_TIME_SCHEDULE):
-            dat_sc = dat.get("sc", {}) if isinstance(dat, dict) else {}
-            if isinstance(dat_sc, dict) and "once" in dat_sc:
-                self.add(DeviceCapability.ONE_TIME_SCHEDULE)
-                self.add(DeviceCapability.EDGE_CUT)
 
         try:
             if "modules" in dat:

--- a/pyworxcloud/utils/capability.py
+++ b/pyworxcloud/utils/capability.py
@@ -81,6 +81,12 @@ class Capability:
         except TypeError:
             pass
 
+        if not self.check(DeviceCapability.ONE_TIME_SCHEDULE):
+            dat_sc = dat.get("sc", {}) if isinstance(dat, dict) else {}
+            if isinstance(dat_sc, dict) and "once" in dat_sc:
+                self.add(DeviceCapability.ONE_TIME_SCHEDULE)
+                self.add(DeviceCapability.EDGE_CUT)
+
         try:
             if "modules" in dat:
                 # Offlimits module

--- a/pyworxcloud/utils/devices.py
+++ b/pyworxcloud/utils/devices.py
@@ -389,6 +389,15 @@ class DeviceHandler(LDict):
             self.capabilities.add(DeviceCapability.ONE_TIME_SCHEDULE)
             self.capabilities.add(DeviceCapability.EDGE_CUT)
 
+        if not self.schedules["one_time_schedule"]:
+            dat_sc = (
+                self.raw_dat.get("sc", {}) if isinstance(self.raw_dat, dict) else {}
+            )
+            if isinstance(dat_sc, dict) and "once" in dat_sc:
+                self.capabilities.add(DeviceCapability.ONE_TIME_SCHEDULE)
+                self.capabilities.add(DeviceCapability.EDGE_CUT)
+                self.schedules["one_time_schedule"] = True
+
     def _determine_updated_at(
         self,
         cfg_payload: dict[str, Any] | None,

--- a/tests/test_device_decode.py
+++ b/tests/test_device_decode.py
@@ -861,6 +861,68 @@ def test_devicehandler_fills_missing_auto_schedule_defaults() -> None:
     )
 
 
+def test_vision_mower_detects_ots_from_dat_sc_once() -> None:
+    """Vision mowers (protocol 1) expose 'once' in dat.sc, not cfg.sc."""
+    payload = {
+        "cfg": {
+            "id": 1,
+            "sn": "SERIAL-VISION-OTS",
+            "rd": 0,
+            "tz": "UTC",
+            "sc": {"enabled": 1, "paused": 0, "slots": []},
+        },
+        "dat": {
+            "uuid": "UUID-VISION-OTS",
+            "mac": "AA:BB:CC:DD:EE:FF",
+            "conn": "online",
+            "ls": 1,
+            "le": 0,
+            "sc": {"once": 0, "slot": 0},
+            "rain": {"s": 0, "cnt": 0},
+        },
+    }
+    mower = _build_mower(payload, 1, "Vision OTS Fixture")
+
+    device = DeviceHandler(api=object(), mower=mower, tz="UTC")
+
+    assert device.capabilities.check(DeviceCapability.ONE_TIME_SCHEDULE) is True
+    assert device.capabilities.check(DeviceCapability.EDGE_CUT) is True
+    assert device.schedules["one_time_schedule"] is True
+
+
+def test_classic_mower_ots_still_detected_from_cfg_sc() -> None:
+    """Protocol 0 mowers with 'ots' in cfg.sc should still work unchanged."""
+    payload = {
+        "cfg": {
+            "id": 1,
+            "sn": "SERIAL-CLASSIC-OTS",
+            "rd": 0,
+            "sc": {
+                "d": [],
+                "dd": False,
+                "ots": {"bc": 0, "wtm": 30},
+            },
+            "tm": "12:00:00",
+            "dt": "11/03/2026",
+            "tz": "UTC",
+        },
+        "dat": {
+            "uuid": "UUID-CLASSIC-OTS",
+            "mac": "AA:BB:CC:DD:EE:FF",
+            "conn": "online",
+            "ls": 1,
+            "le": 0,
+            "rain": {"s": 0, "cnt": 0},
+        },
+    }
+    mower = _build_mower(payload, 0, "Classic OTS Fixture")
+
+    device = DeviceHandler(api=object(), mower=mower, tz="UTC")
+
+    assert device.capabilities.check(DeviceCapability.ONE_TIME_SCHEDULE) is True
+    assert device.capabilities.check(DeviceCapability.EDGE_CUT) is True
+
+
 MQTT_FIXTURES = tuple(fixture_paths("mqtt.json"))
 
 


### PR DESCRIPTION
…wers

Vision mowers (protocol 1) expose the "once" key in dat.sc rather than cfg.sc, so the existing detection paths never found it. Add fallback checks in Capability.__init__ and DeviceHandler._map_cfg that inspect dat.sc when cfg.sc lacks "ots"/"once", enabling the ots() service and Edge Cut button for Vision mowers.

Fixes https://github.com/MTrab/landroid_cloud/issues/1254