### PR TITLE
Switch MQTT transport to Paho-MQTT

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,7 +11,10 @@
     "editor.formatOnSave": true,
     "editor.formatOnType": true,
     "files.trimTrailingWhitespace": true,
-    "[python]": {"editor.defaultFormatter": "ms-python.black-formatter"},
+    "[python]": {
+        "editor.defaultFormatter": "ms-python.black-formatter"
+    },
     "idf.pythonInstallPath": "/usr/bin/python3",
-    "python-envs.defaultEnvManager": "ms-python.python:system",
+    "python-envs.defaultEnvManager": "ms-python.python:poetry",
+    "python-envs.defaultPackageManager": "ms-python.python:poetry",
 }

--- a/poetry.lock
+++ b/poetry.lock
@@ -197,86 +197,6 @@ files = [
 ]
 
 [[package]]
-name = "awscrt"
-version = "0.32.1"
-description = "A common runtime for AWS Python projects"
-optional = false
-python-versions = ">=3.8"
-groups = ["main"]
-files = [
-    {file = "awscrt-0.32.1-cp310-cp310-macosx_10_15_universal2.whl", hash = "sha256:9886714ce14fe9bf3a9ba79af58cdba68f8012658853a31e349e8530ac1db543"},
-    {file = "awscrt-0.32.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1fbcfb39cbbab6efecb3f0317ba3e4e0cfccf13022380449b358da1902124c74"},
-    {file = "awscrt-0.32.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:86d2c65828501e3fb132ce3440274f8696589c89eb1e5b1b6f39816a9c4a9638"},
-    {file = "awscrt-0.32.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:867c4ef556d4a5049012de64adff1edfcf4ab635e71a3de745aa3d64c70141d7"},
-    {file = "awscrt-0.32.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:8ed0e02ee5c7796471c329f7e0b2232e8f4aeea83d742fc5c2e73248cd1f0745"},
-    {file = "awscrt-0.32.1-cp310-cp310-win32.whl", hash = "sha256:51cde3a60b543a1c532b3db2fcc33586e15fb09c5347553c47b48173a5592572"},
-    {file = "awscrt-0.32.1-cp310-cp310-win_amd64.whl", hash = "sha256:f7b1a5773478fc57cd6dc9570ccdea95b2ef688402959543638ab42e04136b12"},
-    {file = "awscrt-0.32.1-cp311-abi3-macosx_10_15_universal2.whl", hash = "sha256:749df69dba2676020e524642df42453087b4bcd12657bc6dfd5fd2e62bc0993a"},
-    {file = "awscrt-0.32.1-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:05a0b4f06dc832907ae8dfdd487d6d881481edffe327cd95836704e08b51467f"},
-    {file = "awscrt-0.32.1-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4b36f48932ddfae10a70440a39b929573f81c6498985f3dfe4d78de8f04a1d0c"},
-    {file = "awscrt-0.32.1-cp311-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:871949f6db4d9ae6568a5508ee30b4335b5c38053ef7483c3d34100f96d734dc"},
-    {file = "awscrt-0.32.1-cp311-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:f3661d0c7ad3386bce56d8db4a30ecb9ce9dc1a04ebf4813955cac94579dbaea"},
-    {file = "awscrt-0.32.1-cp311-abi3-win32.whl", hash = "sha256:fb8699fb522ae8e1b16a86deb411af017aefec0641b1337174c155932a5d870e"},
-    {file = "awscrt-0.32.1-cp311-abi3-win_amd64.whl", hash = "sha256:8ec169ea795af4376eed17986e421ae8ea657c9617a7b7543b6aae45154962c3"},
-    {file = "awscrt-0.32.1-cp313-abi3-macosx_10_15_universal2.whl", hash = "sha256:a0c19f10106c2ed27c72958070ac95f104dbff90809cdf2d1044fbdddd5e7aaf"},
-    {file = "awscrt-0.32.1-cp313-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a02e3e30629ed76ef3a4abeeaa0fc5d3b80c97c773401ba1fc9124f041923793"},
-    {file = "awscrt-0.32.1-cp313-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d8111f153f64f5dbac2336a0fb2fdc326b7d2600306be6d9141e88b210bd9e98"},
-    {file = "awscrt-0.32.1-cp313-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:059697cf8f16530d1a780eab4bd0a798840e1ed2df33cf2b9bd04a02d6eb2f60"},
-    {file = "awscrt-0.32.1-cp313-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:6a5d11ebd2e5bcac662aedfd96ec9267c43d723342d0ebcff181e37d55f4a8b4"},
-    {file = "awscrt-0.32.1-cp313-abi3-win32.whl", hash = "sha256:85ee9e9b8755bb3e3f1d52c645e21444f9e0cdbe306e338256f5adee87dc966c"},
-    {file = "awscrt-0.32.1-cp313-abi3-win_amd64.whl", hash = "sha256:f83a8293479b4152065ba9f7c840035c97d52a494e4cf47ec6447c8b7789fa36"},
-    {file = "awscrt-0.32.1-cp313-cp313t-macosx_10_15_universal2.whl", hash = "sha256:9226b75ec41d7256589dca3b77f935e9b3f6e1e85501e5d8719af38c765730e8"},
-    {file = "awscrt-0.32.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6e002d83f506cc4ffbf6a54602f29c304a0f9270451e1f62af8be15e56e7d6a8"},
-    {file = "awscrt-0.32.1-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e56555770874c625fd3056f4ffc96fa7c66a075c7c793485efb219a09fe5664a"},
-    {file = "awscrt-0.32.1-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:f809bf627eb0db3b80c7c71c81a472aa24b8d03b162ac49764256bdffe35c7a2"},
-    {file = "awscrt-0.32.1-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:813780c6f13f14d9b23b240cb67682c79fa3c551dd2397239afbf35348f263c1"},
-    {file = "awscrt-0.32.1-cp313-cp313t-win32.whl", hash = "sha256:0690c555aeaa3d0caaefa356c46af6d4ea87385ff9dba54f76d29f2fc11dc2de"},
-    {file = "awscrt-0.32.1-cp313-cp313t-win_amd64.whl", hash = "sha256:0883faf5083046253251b9c8be27ca2f5e549755ed47e2d692b3a2a206f0fe5b"},
-    {file = "awscrt-0.32.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:385a6c92805d78c9d569837a631421513e8fbd948cea33fa6fb4cfd3f308c595"},
-    {file = "awscrt-0.32.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8dfc79c717da3d81563f49dc71861748b7d3666e13ba48adb8a74681b0908b42"},
-    {file = "awscrt-0.32.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ec663c7bcafc8e5e6c1cd2032b3c5151a6cf6b0238eb1f343b42220d4a1c2425"},
-    {file = "awscrt-0.32.1-cp314-cp314t-win32.whl", hash = "sha256:30ac7b2f87c3ccfa9c81ab9477cc1a34322b583b80b8802a1cd3fda200cf4a9f"},
-    {file = "awscrt-0.32.1-cp314-cp314t-win_amd64.whl", hash = "sha256:89b5bf2f427a3d0272cd8b8bb8e8bcf0643bfaa118ce33ef2b3ebb4a432e9d62"},
-    {file = "awscrt-0.32.1-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:f9d317d5e6b0b1e64c777e1c4a862f4b605bcd26a6ec28d9c14c1030506e3b9d"},
-    {file = "awscrt-0.32.1-cp38-cp38-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e0bcb28a3a9f728d999b96514ebf5dd1e716aae4a63533627a718ed6bed493d3"},
-    {file = "awscrt-0.32.1-cp38-cp38-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:301d67193a478cc672678b72f7944669c19857758462b2aa5759d4d676d4b867"},
-    {file = "awscrt-0.32.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:80c440b25670ef3bac780b7d524e3e82c33685da7b207d52b21fa0a53b6fcd9e"},
-    {file = "awscrt-0.32.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:6e0f37fb78f7c27ec02cd141b345b3c03dc1e7814887d38d4de2699069eb7395"},
-    {file = "awscrt-0.32.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:2a8d9ed762a8d01cb88487cc4849f3d44b7061c45b019365936fc2c255fbd54e"},
-    {file = "awscrt-0.32.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:4221e711230df0d9a66e9755c0bb3de6e509c2c8292453c2fd44721ea5c08c27"},
-    {file = "awscrt-0.32.1-cp38-cp38-win32.whl", hash = "sha256:1bc98d41fa5c7982aee83a9f3b333b3215c7d5d42a9db54a59f30eca2abcb18a"},
-    {file = "awscrt-0.32.1-cp38-cp38-win_amd64.whl", hash = "sha256:3cd2a8ac4ac9332b0528497449272ff6b6907bb1b216297143656fdc03259338"},
-    {file = "awscrt-0.32.1-cp39-cp39-macosx_10_15_universal2.whl", hash = "sha256:9221382bccbfc664e665a6b9b21cac7766973af3e5aeb4c750b22c5af28c962b"},
-    {file = "awscrt-0.32.1-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2d9c605ac8f34c3998a61525ae8994844fdb0dca82b062d4528f3a09fe7f413b"},
-    {file = "awscrt-0.32.1-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:de3dcbf18266993c87f7ddea21f003366a3ed5ff0a287e9a4f9e9e753c96418e"},
-    {file = "awscrt-0.32.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:bf867180354549f1f035910617d0baf546428db5b10ebb65bfba264bc4505366"},
-    {file = "awscrt-0.32.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:88f22648683b91bb1d644b7d9b62ffe79542e9f80104c3b49d5eda5fd113d49b"},
-    {file = "awscrt-0.32.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:2c5c20bd6fd46d2001c5581013a97b74083500e4e7dac4c566a6558c79c2547b"},
-    {file = "awscrt-0.32.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:4328760f605bcfc3d1a41b9b546078c16f8ae2d7771c6beffa97549650540710"},
-    {file = "awscrt-0.32.1-cp39-cp39-win32.whl", hash = "sha256:99e288027ac4b178ea826d2420b4b6d580b07eef340e68e2f958057bc237cdf0"},
-    {file = "awscrt-0.32.1-cp39-cp39-win_amd64.whl", hash = "sha256:92bf90ca6ad62fed8c893bae068373a7237b7bc9709d579a8fbf82c5a7dbffe7"},
-    {file = "awscrt-0.32.1.tar.gz", hash = "sha256:1faccfaf365c7ae8975307e42edec44eb3ae3feba2805aff2979ba8474b6bb4f"},
-]
-
-[package.extras]
-dev = ["autopep8 (>=2.3.1)", "build (>=1.2.2)", "h2 (==4.1.0)", "sphinx (>=7.2.6,<7.3) ; python_version >= \"3.9\"", "websockets (>=13.1)"]
-
-[[package]]
-name = "awsiotsdk"
-version = "1.29.0"
-description = "AWS IoT SDK based on the AWS Common Runtime"
-optional = false
-python-versions = ">=3.8"
-groups = ["main"]
-files = [
-    {file = "awsiotsdk-1.29.0-py3-none-any.whl", hash = "sha256:3836badc1548b581707106f9104d5fe0b041c105f6ccc0aef664cefe170259b9"},
-    {file = "awsiotsdk-1.29.0.tar.gz", hash = "sha256:a146662b8aadadd13494c027394416a1e6f631962e2528a5700ae1e86ca7b95d"},
-]
-
-[package.dependencies]
-awscrt = "0.32.1"
-
-[[package]]
 name = "certifi"
 version = "2025.6.15"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -761,6 +681,21 @@ files = [
 ]
 
 [[package]]
+name = "paho-mqtt"
+version = "2.1.0"
+description = "MQTT version 5.0/3.1.1 client class"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "paho_mqtt-2.1.0-py3-none-any.whl", hash = "sha256:6db9ba9b34ed5bc6b6e3812718c7e06e2fd7444540df2455d2c51bd58808feee"},
+    {file = "paho_mqtt-2.1.0.tar.gz", hash = "sha256:12d6e7511d4137555a3f6ea167ae846af2c7357b10bc6fa4f7c3968fc1723834"},
+]
+
+[package.extras]
+proxy = ["pysocks"]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 description = "plugin and hook calling mechanisms for python"
@@ -1218,4 +1153,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.9"
-content-hash = "98520fb5816ae1856aab2f26418d348808807ed2944af5ce64d72694d7cb9038"
+content-hash = "2dc0dcc82a184422bd1d1c970a1e62175bc64058c3a049850f89b28f1dbdb17d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ readme = "README.md"
 python = "^3.9"
 urllib3 = ">=1.26.5"
 requests = "^2.32.0"
-awsiotsdk = ">=1.29.0,<1.30.0"
+paho-mqtt = "^2.1.0"
 aiohttp = "^3.11.0"
 tzdata = ">=2024.1"
 

--- a/pyworxcloud/__init__.py
+++ b/pyworxcloud/__init__.py
@@ -354,7 +354,8 @@ class WorxCloud(dict):
 
             self._log.debug("Setting up MQTT handler")
             # setup MQTT handler
-            self.mqtt = MQTT(
+            self.mqtt = await asyncio.to_thread(
+                MQTT,
                 self._api,
                 self._cloud.BRAND_PREFIX,
                 self._endpoint,

--- a/pyworxcloud/__init__.py
+++ b/pyworxcloud/__init__.py
@@ -1014,7 +1014,7 @@ class WorxCloud(dict):
         )
         await self.set_schedule(serial_number, schedule)
 
-    async def update(self, serial_number: str) -> None:
+    async def update(self, serial_number: str, timeout: float | None = None) -> None:
         """Request a state refresh."""
         mower = self.get_mower(serial_number)
         _LOGGER.debug("Trying to refresh '%s'", serial_number)
@@ -1024,6 +1024,7 @@ class WorxCloud(dict):
                 serial_number if mower["protocol"] == 0 else mower["uuid"],
                 mower["mqtt_topics"]["command_in"],
                 mower["protocol"],
+                timeout=timeout,
             )
         except NoConnectionError:
             raise NoConnectionError from None

--- a/pyworxcloud/utils/devices.py
+++ b/pyworxcloud/utils/devices.py
@@ -415,11 +415,14 @@ class DeviceHandler(LDict):
             dt_split = cfg_payload["dt"].split("/")
             time_value = cfg_payload.get("tm", "00:00:00")
             try:
+                timestamp = datetime.fromisoformat(
+                    f"{dt_split[2]}-{dt_split[1]}-{dt_split[0]} {time_value}"
+                ).replace(tzinfo=timezone.utc)
                 return (
-                    datetime.fromisoformat(
-                        f"{dt_split[2]}-{dt_split[1]}-{dt_split[0]} {time_value}"
-                    ).replace(tzinfo=self._resolve_updated_timezone(cfg_payload)),
-                    "cfg_tm",
+                    timestamp.astimezone(
+                        ZoneInfo(self._resolve_effective_timezone(cfg_payload))
+                    ),
+                    "cfg_tm_utc",
                 )
             except ValueError:
                 pass
@@ -473,26 +476,6 @@ class DeviceHandler(LDict):
             if timezone_name is not None:
                 return timezone_name
         return "UTC"
-
-    def _resolve_updated_timezone(self, cfg_payload: dict[str, Any] | None) -> Any:
-        """Resolve timezone for legacy cfg date/time payloads."""
-        if (timezone_name := self._normalize_timezone_name(self._tz)) is not None:
-            return ZoneInfo(timezone_name)
-
-        local_timezone = datetime.now().astimezone().tzinfo
-        if local_timezone is not None:
-            return local_timezone
-
-        for candidate in (
-            cfg_payload.get("tz") if isinstance(cfg_payload, dict) else None,
-            self.time_zone,
-            "UTC",
-        ):
-            timezone_name = self._normalize_timezone_name(candidate)
-            if timezone_name is not None:
-                return ZoneInfo(timezone_name)
-
-        return timezone.utc
 
     def update_attribute(self, device: str, attr: str, key: str, value: Any) -> None:
         """Used as callback to update value."""

--- a/pyworxcloud/utils/devices.py
+++ b/pyworxcloud/utils/devices.py
@@ -401,7 +401,13 @@ class DeviceHandler(LDict):
             if isinstance(tm_value, str) and tm_value.endswith("Z"):
                 tm_value = f"{tm_value[:-1]}+00:00"
             try:
-                return datetime.fromisoformat(tm_value), "dat_tm"
+                timestamp = datetime.fromisoformat(tm_value)
+                return (
+                    timestamp.astimezone(
+                        ZoneInfo(self._resolve_effective_timezone(cfg_payload))
+                    ),
+                    "dat_tm",
+                )
             except ValueError:
                 pass
 

--- a/pyworxcloud/utils/mqtt.py
+++ b/pyworxcloud/utils/mqtt.py
@@ -74,7 +74,8 @@ def _wait_for_operation(result: Any, timeout: float | None = None) -> None:
         return
 
     if hasattr(result, "wait_for_publish"):
-        if not result.wait_for_publish(timeout=timeout):
+        publish_result = result.wait_for_publish(timeout=timeout)
+        if publish_result is False:
             raise FutureTimeoutError(f"timed out after {timeout}")
         if _operation_failed(getattr(result, "rc", MQTT_CONNECT_ACCEPTED)):
             raise RuntimeError(f"MQTT publish failed with result {result.rc}")

--- a/pyworxcloud/utils/mqtt.py
+++ b/pyworxcloud/utils/mqtt.py
@@ -32,6 +32,7 @@ MQTT_CONNECT_ACCEPTED = 0
 DEFAULT_RESPONSE_TIMEOUT = 30.0
 DEFAULT_DISCONNECT_TIMEOUT = 0.5
 DEFAULT_SHUTDOWN_TIMEOUT = 0.25
+DEFAULT_LOOP_STOP_TIMEOUT = 0.5
 MQTT_PORT = 443
 MQTT_KEEPALIVE = 30
 MQTT_WEBSOCKET_PATH = "/mqtt"
@@ -624,11 +625,31 @@ class MQTT(LDict):
         loop_stop = getattr(client, "loop_stop", None)
         if loop_stop is None:
             return
-        try:
-            loop_stop()
-        except Exception:  # pragma: no cover - defensive teardown path
+        finished = threading.Event()
+        errors: list[Exception] = []
+
+        def _stop_loop() -> None:
+            try:
+                loop_stop()
+            except Exception as exc:  # pragma: no cover - defensive teardown path
+                errors.append(exc)
+            finally:
+                finished.set()
+
+        thread = threading.Thread(
+            target=_stop_loop,
+            name="pyworxcloud-mqtt-loop-stop",
+            daemon=True,
+        )
+        thread.start()
+        if not finished.wait(DEFAULT_LOOP_STOP_TIMEOUT):
             self._log.getChild("MQTT_Disconnect").debug(
-                "MQTT loop_stop raised during teardown", exc_info=True
+                "MQTT loop_stop timed out after %.3fs", DEFAULT_LOOP_STOP_TIMEOUT
+            )
+            return
+        if errors:
+            self._log.getChild("MQTT_Disconnect").debug(
+                "MQTT loop_stop raised during teardown: %s", errors[0]
             )
 
     def _release_pending_response_waiter(self) -> None:

--- a/pyworxcloud/utils/mqtt.py
+++ b/pyworxcloud/utils/mqtt.py
@@ -181,6 +181,7 @@ class MQTT(LDict):
         self._response_event = threading.Event()
         self._pending_response_target: str | None = None
         self._pending_response_message_id: int | None = None
+        self._pending_response_accepts_any_message_id = False
         self._pending_command_signature: tuple[str, str, int, str] | None = None
         self._last_command_payload: dict[str, Any] | None = None
         self._lifecycle_lock = threading.RLock()
@@ -450,7 +451,8 @@ class MQTT(LDict):
         expanded_identifiers = self._expand_identifiers(identifiers)
         with self._response_lock:
             id_matches = (
-                not message_ids
+                self._pending_response_accepts_any_message_id
+                or not message_ids
                 or self._pending_response_message_id is None
                 or self._pending_response_message_id in message_ids
             )
@@ -629,9 +631,19 @@ class MQTT(LDict):
                 "MQTT loop_stop raised during teardown", exc_info=True
             )
 
+    def _release_pending_response_waiter(self) -> None:
+        """Wake any command currently waiting for a mower response."""
+        with self._response_lock:
+            self._pending_response_target = None
+            self._pending_response_message_id = None
+            self._pending_response_accepts_any_message_id = False
+            self._pending_command_signature = None
+            self._response_event.set()
+
     def disconnect(self, keep_topic: bool = False) -> None:
         """Disconnect from the MQTT server."""
         logger = self._log.getChild("MQTT_Disconnect")
+        self._release_pending_response_waiter()
         with self._lifecycle_lock:
             if self._shutdown_event:
                 self._is_connected = False
@@ -683,6 +695,7 @@ class MQTT(LDict):
     def shutdown(self) -> None:
         """Release MQTT client resources."""
         logger = self._log.getChild("MQTT_Shutdown")
+        self._release_pending_response_waiter()
         with self._lifecycle_lock:
             if self._shutdown_event:
                 return
@@ -881,6 +894,9 @@ class MQTT(LDict):
             with self._response_lock:
                 self._pending_response_target = serial_number
                 self._pending_response_message_id = command_message_id
+                self._pending_response_accepts_any_message_id = (
+                    message.get("cmd") == Command.FORCE_REFRESH
+                )
                 self._pending_command_signature = command_signature
                 self._response_event.clear()
 
@@ -908,6 +924,7 @@ class MQTT(LDict):
                 with self._response_lock:
                     self._pending_response_target = None
                     self._pending_response_message_id = None
+                    self._pending_response_accepts_any_message_id = False
                     self._pending_command_signature = None
                     self._response_event.clear()
 

--- a/pyworxcloud/utils/mqtt.py
+++ b/pyworxcloud/utils/mqtt.py
@@ -1,18 +1,8 @@
 """MQTT information class.
 
-This module provides an MQTT client for connecting to AWS IoT MQTT using the AWS IoT Device SDK for Python v2.
-It handles connection, subscription, and message publishing to AWS IoT MQTT endpoints.
-
-Dependencies:
-- awscrt: AWS Common Runtime library
-- awsiot: AWS IoT Device SDK for Python v2
-
-The MQTT class provides the following functionality:
-- Connection to AWS IoT MQTT with custom authentication using JWT tokens
-- Subscription to topics
-- Publishing messages to topics
-- Handling reconnection and token updates
-- Formatting messages for different protocols
+This module provides an MQTT client for connecting to the Landroid Cloud MQTT
+endpoint over WebSockets using paho-mqtt. It handles connection, subscription,
+publishing, token refreshes, response matching, and command deduplication.
 """
 
 from __future__ import annotations
@@ -21,87 +11,76 @@ import asyncio
 import itertools
 import json
 import random
+import ssl
 import threading
 import time
 import urllib.parse
-from concurrent.futures import Future
 from concurrent.futures import TimeoutError as FutureTimeoutError
 from datetime import datetime, timezone
 from logging import Logger
 from typing import Any, Callable, Optional
 from uuid import uuid4
 
-import awscrt.io
-import awscrt.mqtt
-from awsiot import mqtt_connection_builder
+import paho.mqtt.client as paho_mqtt
 
 from ..events import EventHandler, LandroidEvent
 from ..exceptions import NoConnectionError, TimeoutException
 from .landroid_class import LDict
 
-QOS_FLAG = awscrt.mqtt.QoS.AT_LEAST_ONCE
+QOS_FLAG = 1
+MQTT_CONNECT_ACCEPTED = 0
 DEFAULT_RESPONSE_TIMEOUT = 30.0
 DEFAULT_DISCONNECT_TIMEOUT = 0.5
 DEFAULT_SHUTDOWN_TIMEOUT = 0.25
-AWSCRT_CONNECT_ARG_MISMATCH = "function takes exactly 18 arguments (17 given)"
+MQTT_PORT = 443
+MQTT_KEEPALIVE = 30
+MQTT_WEBSOCKET_PATH = "/mqtt"
 
 
-def _is_awscrt_connect_arg_mismatch(err: TypeError) -> bool:
-    """Return whether AWS CRT hit the known 0.32.x connect arg mismatch."""
-    return AWSCRT_CONNECT_ARG_MISMATCH in str(err)
-
-
-def _legacy_connect_without_metrics(client: Any) -> Future:
-    """Call the pre-0.32 AWS CRT connect signature for mixed installations."""
-    import _awscrt  # pylint: disable=import-outside-toplevel
-    import awscrt.exceptions  # pylint: disable=import-outside-toplevel
-
-    future = Future()
-
-    def on_connect(error_code, return_code, session_present):
-        if return_code:
-            future.set_exception(Exception(awscrt.mqtt.ConnectReturnCode(return_code)))
-        elif error_code:
-            future.set_exception(awscrt.exceptions.from_code(error_code))
-        else:
-            future.set_result(dict(session_present=session_present))
-
-    _awscrt.mqtt_client_connection_connect(
-        client._binding,
-        client.client_id,
-        client.host_name,
-        client.port,
-        client.socket_options,
-        client.client.tls_ctx,
-        client.reconnect_min_timeout_secs,
-        client.reconnect_max_timeout_secs,
-        client.keep_alive_secs,
-        client.ping_timeout_ms,
-        client.protocol_operation_timeout_ms,
-        client.will,
-        client.username,
-        client.password,
-        client.clean_session,
-        on_connect,
-        client.proxy_options,
-    )
-
-    return future
-
-
-def _connect_with_awscrt_compat(client: Any, logger: Logger) -> Future:
-    """Connect while tolerating the awscrt 0.32.x mixed-installation bug."""
+def _reason_code_value(reason_code: Any) -> int:
+    """Return an integer result code for paho reason code variants."""
     try:
-        return client.connect()
-    except TypeError as err:
-        if not _is_awscrt_connect_arg_mismatch(err):
-            raise
+        return int(reason_code)
+    except (TypeError, ValueError):
+        value = getattr(reason_code, "value", reason_code)
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return MQTT_CONNECT_ACCEPTED if str(reason_code) == "Success" else -1
 
-        logger.warning(
-            "AWS CRT connect hit the known 17/18-argument mismatch; "
-            "retrying with legacy compatibility path"
-        )
-        return _legacy_connect_without_metrics(client)
+
+def _operation_failed(result: Any) -> bool:
+    """Return whether a paho operation result indicates failure."""
+    if result is None:
+        return False
+    if isinstance(result, tuple):
+        result = result[0]
+    if hasattr(result, "rc"):
+        result = result.rc
+    return _reason_code_value(result) != MQTT_CONNECT_ACCEPTED
+
+
+def _wait_for_operation(result: Any, timeout: float | None = None) -> None:
+    """Wait for AWS-style futures, paho publish infos, or paho return codes."""
+    if isinstance(result, tuple):
+        result = result[0]
+
+    if hasattr(result, "result"):
+        try:
+            result.result(timeout=timeout)
+        except TypeError:
+            result.result()
+        return
+
+    if hasattr(result, "wait_for_publish"):
+        if not result.wait_for_publish(timeout=timeout):
+            raise FutureTimeoutError(f"timed out after {timeout}")
+        if _operation_failed(getattr(result, "rc", MQTT_CONNECT_ACCEPTED)):
+            raise RuntimeError(f"MQTT publish failed with result {result.rc}")
+        return
+
+    if _operation_failed(result):
+        raise RuntimeError(f"MQTT operation failed with result {result}")
 
 
 class MQTTMsgType(LDict):
@@ -180,7 +159,7 @@ class MQTT(LDict):
         deduplicate_inflight_commands: bool = False,
         response_timeout: float = DEFAULT_RESPONSE_TIMEOUT,
     ) -> dict:
-        """Initialize AWSIoT MQTT handler."""
+        """Initialize the paho-mqtt handler."""
 
         super().__init__()
         self._events = EventHandler()
@@ -196,7 +175,7 @@ class MQTT(LDict):
         self._is_connected: bool = False
         self._brandprefix = brandprefix
         self._user_id = user_id
-        self._connection_future: Optional[Future] = None
+        self._connection_future: Optional[Any] = None
         self._command_lock = threading.Lock()
         self._response_lock = threading.Lock()
         self._response_event = threading.Event()
@@ -207,6 +186,8 @@ class MQTT(LDict):
         self._lifecycle_lock = threading.RLock()
         self._token_update_lock = threading.Lock()
         self._ready_event = threading.Event()
+        self._connect_event = threading.Event()
+        self._connect_error: Exception | None = None
         self._message_id_lock = threading.Lock()
         self._message_id_seq = itertools.count(random.randint(1024, 65535))
         self._client_generation = 0
@@ -222,54 +203,59 @@ class MQTT(LDict):
         self._disconnect_timeout = DEFAULT_DISCONNECT_TIMEOUT
         self._shutdown_timeout = DEFAULT_SHUTDOWN_TIMEOUT
 
-        # Create event loop group and connection
-        self._event_loop_group = awscrt.io.EventLoopGroup(1)
-        self._host_resolver = awscrt.io.DefaultHostResolver(self._event_loop_group)
-        self._client_bootstrap = awscrt.io.ClientBootstrap(
-            self._event_loop_group, self._host_resolver
-        )
-
-        # Create the MQTT connection
         self.client = self._create_mqtt_connection()
 
-    def _create_mqtt_connection(self):
-        """Create an MQTT connection using awsiot.mqtt_connection_builder."""
+    def _create_paho_client(self) -> paho_mqtt.Client:
+        """Create a paho client across supported paho-mqtt versions."""
+        callback_api_version = getattr(paho_mqtt, "CallbackAPIVersion", None)
+        if callback_api_version is not None:
+            return paho_mqtt.Client(
+                callback_api_version.VERSION2,
+                client_id=self._client_id,
+                clean_session=False,
+                transport="websockets",
+            )
+        return paho_mqtt.Client(
+            client_id=self._client_id,
+            clean_session=False,
+            transport="websockets",
+        )
+
+    def _create_mqtt_connection(self) -> paho_mqtt.Client:
+        """Create an MQTT connection using paho-mqtt over secure WebSockets."""
         generation = self._client_generation + 1
         self._client_generation = generation
         self._active_generation = generation
 
-        # Format the JWT token for authentication
         accesstokenparts = (
             self._api.access_token.replace("_", "/").replace("-", "+").split(".")
         )
-        username = f"bot?jwt={urllib.parse.quote(accesstokenparts[0])}.{urllib.parse.quote(accesstokenparts[1])}&x-amz-customauthorizer-name=''&x-amz-customauthorizer-signature={urllib.parse.quote(accesstokenparts[2])}"
-
-        # Create the MQTT connection
-        mqtt_connection = mqtt_connection_builder.websockets_with_custom_authorizer(
-            endpoint=self._endpoint,
-            client_id=self._client_id,
-            auth_username=username,
-            auth_password=None,
-            client_bootstrap=self._client_bootstrap,
-            on_connection_interrupted=lambda connection, error, **kwargs: (
-                self._on_connection_interrupted(
-                    connection, error, generation=generation, **kwargs
-                )
-            ),
-            on_connection_resumed=lambda connection, return_code, session_present, **kwargs: (
-                self._on_connection_resumed(
-                    connection,
-                    return_code,
-                    session_present,
-                    generation=generation,
-                    **kwargs,
-                )
-            ),
-            clean_session=False,
-            keep_alive_secs=30,
+        username = (
+            "bot?jwt="
+            f"{urllib.parse.quote(accesstokenparts[0])}."
+            f"{urllib.parse.quote(accesstokenparts[1])}"
+            "&x-amz-customauthorizer-name=''"
+            "&x-amz-customauthorizer-signature="
+            f"{urllib.parse.quote(accesstokenparts[2])}"
         )
 
-        return mqtt_connection
+        client = self._create_paho_client()
+        client.username_pw_set(username=username, password=None)
+        client.tls_set(cert_reqs=ssl.CERT_REQUIRED)
+        client.ws_set_options(path=MQTT_WEBSOCKET_PATH)
+        client.reconnect_delay_set(min_delay=1, max_delay=32)
+        client.on_connect = lambda client, userdata, flags, reason_code, *args: (
+            self._on_paho_connect(
+                client, userdata, flags, reason_code, generation=generation
+            )
+        )
+        client.on_disconnect = lambda client, userdata, *args: self._on_paho_disconnect(
+            client, userdata, *args, generation=generation
+        )
+        client.on_message = lambda client, userdata, message: self._on_message_received(
+            message.topic, message.payload, generation=generation
+        )
+        return client
 
     def _is_stale_generation(self, generation: int | None) -> bool:
         """Return whether a callback generation no longer matches the active client."""
@@ -288,6 +274,14 @@ class MQTT(LDict):
                 ready_event.set()
         return ready_event
 
+    def _get_connect_event(self) -> threading.Event:
+        """Return the connect event, creating it for bare test fixtures if needed."""
+        connect_event = getattr(self, "_connect_event", None)
+        if connect_event is None:
+            connect_event = threading.Event()
+            self._connect_event = connect_event
+        return connect_event
+
     def _resubscribe_topic(self, topic: str, generation: int | None = None) -> None:
         """Resubscribe while tolerating older monkeypatched subscribe signatures."""
         try:
@@ -298,7 +292,7 @@ class MQTT(LDict):
             self.subscribe(topic, False)
 
     def _schedule_reconnect_after_resume(self) -> None:
-        """Kick off a full client rebuild after an AWS-level resume callback."""
+        """Kick off a full client rebuild after a broker-level reconnect."""
         worker = threading.Thread(
             target=self._reconnect_after_resume,
             name="pyworxcloud-mqtt-resume-reconnect",
@@ -307,7 +301,7 @@ class MQTT(LDict):
         worker.start()
 
     def _reconnect_after_resume(self) -> None:
-        """Rebuild the MQTT client after a resume callback we do not trust."""
+        """Rebuild the MQTT client after a reconnect callback we do not trust."""
         try:
             self.update_token()
         except Exception:  # pragma: no cover - defensive logging path
@@ -316,7 +310,67 @@ class MQTT(LDict):
                 exc_info=True,
             )
 
-    def _on_connection_interrupted(self, connection, error, **kwargs):
+    def _on_paho_connect(
+        self,
+        connection: Any,
+        _userdata: Any,
+        flags: Any,
+        reason_code: Any,
+        **kwargs: Any,
+    ) -> None:
+        """Handle paho on_connect callbacks."""
+        generation = kwargs.get("generation")
+        if self._is_stale_generation(generation):
+            self._log.getChild("Conn_State").debug(
+                "Ignoring stale connection callback for generation %s", generation
+            )
+            return
+
+        if _reason_code_value(reason_code) == MQTT_CONNECT_ACCEPTED:
+            self._is_connected = True
+            self._connect_error = None
+        else:
+            self._is_connected = False
+            self._connect_error = NoConnectionError(
+                f"MQTT connection rejected with result {reason_code}"
+            )
+        self._get_connect_event().set()
+
+        session_present = False
+        if isinstance(flags, dict):
+            session_present = bool(flags.get("session present", False))
+        else:
+            session_present = bool(getattr(flags, "session_present", False))
+        self._log.getChild("Conn_State").debug(
+            "Connection callback. reason_code: %s, session_present: %s",
+            reason_code,
+            session_present,
+        )
+        del connection
+
+    def _on_paho_disconnect(
+        self, connection: Any, _userdata: Any, *args: Any, **kwargs: Any
+    ) -> None:
+        """Handle paho on_disconnect callbacks."""
+        generation = kwargs.get("generation")
+        if self._is_stale_generation(generation):
+            self._log.getChild("Conn_State").debug(
+                "Ignoring stale disconnect callback for generation %s", generation
+            )
+            return
+
+        reason_code = args[-2] if len(args) >= 2 else args[-1] if args else 0
+        if _reason_code_value(reason_code) != MQTT_CONNECT_ACCEPTED:
+            self._on_connection_interrupted(
+                connection, reason_code, generation=generation
+            )
+        else:
+            self._is_connected = False
+            self._get_ready_event().clear()
+
+    def _on_connection_interrupted(
+        self, connection: Any, error: Any, **kwargs: Any
+    ) -> None:
         """Callback when a connection is accidentally lost."""
         del connection
         logger = self._log.getChild("Conn_State")
@@ -331,12 +385,12 @@ class MQTT(LDict):
         self._is_connected = False
         self._get_ready_event().clear()
         self._awaiting_post_resume_message = False
-        logger.debug(f"Connection interrupted. error: {error}")
+        logger.debug("Connection interrupted. error: %s", error)
         self._events.call(LandroidEvent.MQTT_CONNECTION, state=False)
 
     def _on_connection_resumed(
-        self, connection, return_code, session_present, **kwargs
-    ):
+        self, connection: Any, return_code: Any, session_present: bool, **kwargs: Any
+    ) -> None:
         """Callback when an interrupted connection is re-established."""
         del connection
         logger = self._log.getChild("Conn_State")
@@ -348,16 +402,17 @@ class MQTT(LDict):
             )
             return
 
-        self._is_connected = True
         logger.debug(
-            f"Connection resumed. return_code: {return_code}, session_present: {session_present}"
+            "Connection resumed. return_code: %s, session_present: %s",
+            return_code,
+            session_present,
         )
 
         self._is_connected = False
         self._get_ready_event().clear()
         self._awaiting_post_resume_message = False
 
-        if return_code == awscrt.mqtt.ConnectReturnCode.ACCEPTED:
+        if _reason_code_value(return_code) == MQTT_CONNECT_ACCEPTED:
             if session_present:
                 logger.debug(
                     "Session resumed, but forcing a full MQTT reconnect before trusting it"
@@ -376,10 +431,9 @@ class MQTT(LDict):
     def connected(self) -> bool:
         """Returns the MQTT connection state."""
         return self._is_connected
-        # return self.client.is_connected()
 
     def _on_message_received(
-        self, topic: str, payload: bytes, generation: int | None = None, **kwargs
+        self, topic: str, payload: bytes, generation: int | None = None, **kwargs: Any
     ) -> None:
         """Callback when a message is received."""
         del kwargs
@@ -468,17 +522,10 @@ class MQTT(LDict):
         callback_generation = (
             self._active_generation if generation is None else generation
         )
-        subscribe_future, _ = client.subscribe(
-            topic=topic,
-            qos=QOS_FLAG,
-            callback=lambda topic, payload, **kwargs: self._on_message_received(
-                topic, payload, generation=callback_generation, **kwargs
-            ),
-        )
-
-        # Wait for a subscription to be confirmed
-        subscribe_future.result()
-        self._log.debug(f"Subscribed to topic: {topic}")
+        result = client.subscribe(topic=topic, qos=QOS_FLAG)
+        _wait_for_operation(result)
+        self._active_generation = callback_generation
+        self._log.debug("Subscribed to topic: %s", topic)
 
     async def asubscribe(
         self, topic: str, append: bool = True, generation: int | None = None
@@ -495,12 +542,23 @@ class MQTT(LDict):
             raise NoConnectionError("MQTT client is not available")
 
         self._get_ready_event().clear()
+        connect_event = self._get_connect_event()
+        connect_event.clear()
+        self._connect_error = None
         try:
-            # Create a connection future
-            self._connection_future = _connect_with_awscrt_compat(client, self._log)
+            self._connection_future = None
+            result = client.connect(
+                self._endpoint,
+                port=MQTT_PORT,
+                keepalive=MQTT_KEEPALIVE,
+            )
+            _wait_for_operation(result)
+            client.loop_start()
 
-            # Wait for connection to complete
-            self._connection_future.result()
+            if not connect_event.wait(self._response_timeout):
+                raise TimeoutException("Timed out waiting for MQTT connection")
+            if self._connect_error is not None:
+                raise self._connect_error
 
             with self._lifecycle_lock:
                 if generation != self._active_generation or client is not self.client:
@@ -510,17 +568,14 @@ class MQTT(LDict):
                     )
                     return
 
-                # Update connection state
                 self._is_connected = True
                 self._reconnected = False
                 self._awaiting_post_resume_message = False
 
-            # Subscribe to saved topics
             for topic in self._topic:
-                self._log.debug(f"Subscribing to '{topic}'")
+                self._log.debug("Subscribing to '%s'", topic)
                 self._resubscribe_topic(topic, generation)
 
-            # Notify about connection
             self._get_ready_event().set()
             self._events.call(LandroidEvent.MQTT_CONNECTION, state=True)
 
@@ -528,7 +583,8 @@ class MQTT(LDict):
             self._is_connected = False
             self._connection_future = None
             self._get_ready_event().clear()
-            self._log.error(f"Failed to connect to MQTT: {exc}")
+            self._safe_loop_stop(client)
+            self._log.error("Failed to connect to MQTT: %s", exc)
             raise NoConnectionError() from exc
 
     async def aconnect(self) -> None:
@@ -547,14 +603,10 @@ class MQTT(LDict):
                 self._log.debug("Updating token")
                 self._get_ready_event().clear()
 
-                # Disconnect if connected
                 if self.connected:
                     self.disconnect(keep_topic=True)
 
-                # Create a new connection with updated token
                 self.client = self._create_mqtt_connection()
-
-                # Reconnect
                 self.connect()
 
                 self._log.debug("Token updated")
@@ -565,8 +617,20 @@ class MQTT(LDict):
         """Async token update wrapper."""
         await asyncio.to_thread(self.update_token)
 
-    def disconnect(self, keep_topic: bool = False):  # pylint: disable=unused-argument
-        """Disconnect from AWSIoT MQTT server."""
+    def _safe_loop_stop(self, client: Any) -> None:
+        """Stop the paho network loop when the client supports it."""
+        loop_stop = getattr(client, "loop_stop", None)
+        if loop_stop is None:
+            return
+        try:
+            loop_stop()
+        except Exception:  # pragma: no cover - defensive teardown path
+            self._log.getChild("MQTT_Disconnect").debug(
+                "MQTT loop_stop raised during teardown", exc_info=True
+            )
+
+    def disconnect(self, keep_topic: bool = False) -> None:
+        """Disconnect from the MQTT server."""
         logger = self._log.getChild("MQTT_Disconnect")
         with self._lifecycle_lock:
             if self._shutdown_event:
@@ -575,7 +639,6 @@ class MQTT(LDict):
                 self._get_ready_event().clear()
                 return
 
-            # Clear topic list
             if not keep_topic:
                 self._topic = []
 
@@ -588,13 +651,14 @@ class MQTT(LDict):
             try:
                 if self._is_connected:
                     started = time.perf_counter()
-                    disconnect_future = client.disconnect()
-                    disconnect_future.result(
+                    result = client.disconnect()
+                    _wait_for_operation(
+                        result,
                         timeout=getattr(
                             self,
                             "_disconnect_timeout",
                             DEFAULT_DISCONNECT_TIMEOUT,
-                        )
+                        ),
                     )
                     logger.debug(
                         "MQTT disconnected in %.3fs", time.perf_counter() - started
@@ -607,7 +671,7 @@ class MQTT(LDict):
             except Exception as err:  # pragma: no cover - defensive
                 logger.debug("MQTT disconnect raised during teardown: %s", err)
             finally:
-                # Ensure internal state remains consistent after teardown attempts.
+                self._safe_loop_stop(client)
                 self._is_connected = False
                 self._connection_future = None
                 self._get_ready_event().clear()
@@ -617,34 +681,29 @@ class MQTT(LDict):
         await asyncio.to_thread(self.disconnect, keep_topic)
 
     def shutdown(self) -> None:
-        """Release background AWS CRT resources."""
+        """Release MQTT client resources."""
         logger = self._log.getChild("MQTT_Shutdown")
         with self._lifecycle_lock:
             if self._shutdown_event:
                 return
             self._shutdown_event = True
             was_connected = self._is_connected
-
-            host_resolver = self._host_resolver
-            client_bootstrap = self._client_bootstrap
-            event_loop_group = self._event_loop_group
             client = self.client
 
             self.client = None
-            self._host_resolver = None
-            self._client_bootstrap = None
-            self._event_loop_group = None
             self._is_connected = False
             self._connection_future = None
             self._get_ready_event().clear()
 
-        # Disconnect after detaching internals, so concurrent calls see teardown state.
         if client is not None and was_connected:
             try:
                 started = time.perf_counter()
-                disconnect_future = client.disconnect()
-                disconnect_future.result(
-                    timeout=getattr(self, "_shutdown_timeout", DEFAULT_SHUTDOWN_TIMEOUT)
+                result = client.disconnect()
+                _wait_for_operation(
+                    result,
+                    timeout=getattr(
+                        self, "_shutdown_timeout", DEFAULT_SHUTDOWN_TIMEOUT
+                    ),
                 )
                 logger.debug(
                     "Shutdown disconnect completed in %.3fs",
@@ -661,28 +720,8 @@ class MQTT(LDict):
                     time.perf_counter() - started,
                     exc_info=True,
                 )
-        shutdown_timeout = getattr(self, "_shutdown_timeout", DEFAULT_SHUTDOWN_TIMEOUT)
-        for name, resource in (
-            ("host_resolver", host_resolver),
-            ("client_bootstrap", client_bootstrap),
-            ("event_loop_group", event_loop_group),
-        ):
-            if resource is None:
-                continue
-
-            shutdown_event = getattr(resource, "shutdown_event", None)
-            if shutdown_event is None:
-                logger.debug("Detached %s without shutdown_event", name)
-                continue
-
-            started = time.perf_counter()
-            completed = shutdown_event.wait(shutdown_timeout)
-            logger.debug(
-                "Waited for %s shutdown_event; completed=%s in %.3fs",
-                name,
-                completed,
-                time.perf_counter() - started,
-            )
+            finally:
+                self._safe_loop_stop(client)
 
     async def ashutdown(self) -> None:
         """Async shutdown wrapper."""
@@ -818,7 +857,6 @@ class MQTT(LDict):
         if client is None:
             raise NoConnectionError("MQTT client is not available")
 
-        # Format the message
         formatted_message = self.format_message(serial_number, message, protocol)
         command_message_id = json.loads(formatted_message)["id"]
         identifier_type = "sn" if protocol == 0 else "uuid" if protocol == 1 else "id"
@@ -839,7 +877,6 @@ class MQTT(LDict):
             formatted_message,
         )
 
-        # Only allow one in-flight command until response/timeout.
         with self._command_lock:
             with self._response_lock:
                 self._pending_response_target = serial_number
@@ -848,10 +885,10 @@ class MQTT(LDict):
                 self._response_event.clear()
 
             try:
-                publish_future, _ = client.publish(
+                result = client.publish(
                     topic=topic, payload=formatted_message, qos=QOS_FLAG
                 )
-                publish_future.result()
+                _wait_for_operation(result)
 
                 if not self._response_event.wait(effective_timeout):
                     payload = self._last_command_payload or {}
@@ -901,8 +938,6 @@ class MQTT(LDict):
 
         client = self.client
         if client is not None and not hasattr(client, "connect"):
-            # Lightweight test doubles can inject a publish-only client and mark the
-            # transport as connected without implementing full reconnect support.
             if self.connected:
                 self._get_ready_event().set()
                 return

--- a/test_dashboard_gui.py
+++ b/test_dashboard_gui.py
@@ -291,12 +291,14 @@ class CloudWorker:
         self._log_level = _configure_logging()
         self._update_event = asyncio.Event()
         self._update_event_name: str | None = None
+        self._update_event_serial: str | None = None
 
-    def _mark_update_received(self, name: str) -> None:
+    def _mark_update_received(self, name: str, serial: str | None = None) -> None:
         """Mark update event from any thread in a loop-safe way."""
 
         def _set() -> None:
             self._update_event_name = name
+            self._update_event_serial = serial
             self._update_event.set()
 
         self._loop.call_soon_threadsafe(_set)
@@ -330,7 +332,9 @@ class CloudWorker:
         _configure_logging()
 
         def _on_data(name: str, device: DeviceHandler) -> None:
-            self._mark_update_received(name)
+            self._mark_update_received(
+                name, str(getattr(device, "serial_number", "")) or None
+            )
             self._emit(
                 "device_update",
                 source="mqtt",
@@ -339,7 +343,9 @@ class CloudWorker:
             )
 
         def _on_api(name: str, device: DeviceHandler) -> None:
-            self._mark_update_received(name)
+            self._mark_update_received(
+                name, str(getattr(device, "serial_number", "")) or None
+            )
             self._emit(
                 "device_update",
                 source="api",
@@ -421,14 +427,15 @@ class CloudWorker:
 
         self._update_event.clear()
         self._update_event_name = None
+        self._update_event_serial = None
         self._emit("log", text="Sending forced refresh command...")
-        command_completed = False
+        command_dispatched = False
         try:
             await self._cloud.update(
                 device.serial_number,
                 timeout=DASHBOARD_REFRESH_TIMEOUT,
             )
-            command_completed = True
+            command_dispatched = True
             self._emit("log", text="Forced refresh command sent. Waiting for update...")
         except (NoConnectionError, TimeoutException) as err:
             self._emit(
@@ -439,12 +446,18 @@ class CloudWorker:
                 ),
             )
         got_live_update = False
-        if command_completed:
+        if command_dispatched or self._update_event.is_set():
             try:
                 await asyncio.wait_for(
                     self._update_event.wait(), timeout=DASHBOARD_REFRESH_TIMEOUT
                 )
-                got_live_update = self._update_event_name == selected
+                got_live_update = self._update_matches_selected(selected, identifier)
+            except TimeoutError:
+                got_live_update = False
+        elif not self._update_event.is_set():
+            try:
+                await asyncio.wait_for(self._update_event.wait(), timeout=0.25)
+                got_live_update = self._update_matches_selected(selected, identifier)
             except TimeoutError:
                 got_live_update = False
 
@@ -469,6 +482,18 @@ class CloudWorker:
             at=datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
             source="mqtt" if got_live_update else "api-fallback",
             target=identifier,
+        )
+
+    def _update_matches_selected(self, selected: str, serial: str) -> bool:
+        """Return whether the latest update event belongs to the selected mower."""
+        if self._update_event_serial == serial:
+            return True
+        if self._update_event_name == selected:
+            return True
+        if self._update_event_name is None:
+            return False
+        return self._normalize_key(self._update_event_name) == self._normalize_key(
+            selected
         )
 
     async def _with_selected_serial(self) -> str | None:

--- a/test_dashboard_gui.py
+++ b/test_dashboard_gui.py
@@ -303,6 +303,11 @@ class CloudWorker:
         asyncio.set_event_loop(self._loop)
         self._loop.run_forever()
 
+    def stop(self) -> None:
+        self._loop.call_soon_threadsafe(self._loop.stop)
+        if threading.current_thread() is not self._thread:
+            self._thread.join(timeout=2.0)
+
     def _emit(self, msg_type: str, **payload: Any) -> None:
         self._messages.put(WorkerMessage(msg_type=msg_type, payload=payload))
 
@@ -376,7 +381,6 @@ class CloudWorker:
 
     async def shutdown(self) -> None:
         await self.disconnect()
-        self._loop.call_soon_threadsafe(self._loop.stop)
 
     async def select_mower(self, name: str) -> None:
         if self._cloud is None:
@@ -1144,6 +1148,7 @@ class DashboardApp:
         if self._shutdown_popup is not None:
             with contextlib.suppress(Exception):
                 self._shutdown_popup.destroy()
+        self.worker.stop()
         self.root.destroy()
 
     def run(self) -> None:

--- a/test_dashboard_gui.py
+++ b/test_dashboard_gui.py
@@ -18,6 +18,7 @@ from typing import Any
 
 from pyworxcloud import WorxCloud
 from pyworxcloud.events import LandroidEvent
+from pyworxcloud.exceptions import NoConnectionError, TimeoutException
 from pyworxcloud.utils import DeviceHandler
 
 try:
@@ -27,6 +28,7 @@ except ImportError:  # pragma: no cover - non-Windows runtime
 
 
 REGISTRY_KEY = r"Software\pyworxcloud\Dashboard"
+DASHBOARD_REFRESH_TIMEOUT = 3.0
 
 
 def _load_dotenv(path: str = ".env") -> None:
@@ -420,15 +422,31 @@ class CloudWorker:
         self._update_event.clear()
         self._update_event_name = None
         self._emit("log", text="Sending forced refresh command...")
-        # Keep the exact same refresh entrypoint as CLI dashboard.
-        await self._cloud.update(device.serial_number)
-        self._emit("log", text="Forced refresh command sent. Waiting for update...")
-        got_live_update = False
+        command_completed = False
         try:
-            await asyncio.wait_for(self._update_event.wait(), timeout=3.0)
-            got_live_update = self._update_event_name == selected
-        except TimeoutError:
-            got_live_update = False
+            await self._cloud.update(
+                device.serial_number,
+                timeout=DASHBOARD_REFRESH_TIMEOUT,
+            )
+            command_completed = True
+            self._emit("log", text="Forced refresh command sent. Waiting for update...")
+        except (NoConnectionError, TimeoutException) as err:
+            self._emit(
+                "log",
+                text=(
+                    "Forced refresh command did not complete via MQTT "
+                    f"({type(err).__name__}); running API fallback fetch."
+                ),
+            )
+        got_live_update = False
+        if command_completed:
+            try:
+                await asyncio.wait_for(
+                    self._update_event.wait(), timeout=DASHBOARD_REFRESH_TIMEOUT
+                )
+                got_live_update = self._update_event_name == selected
+            except TimeoutError:
+                got_live_update = False
 
         if not got_live_update:
             # Fallback to API fetch if mower does not publish a changed MQTT payload.

--- a/test_dashboard_gui.py
+++ b/test_dashboard_gui.py
@@ -452,13 +452,13 @@ class CloudWorker:
                     self._update_event.wait(), timeout=DASHBOARD_REFRESH_TIMEOUT
                 )
                 got_live_update = self._update_matches_selected(selected, identifier)
-            except TimeoutError:
+            except (TimeoutError, asyncio.TimeoutError):
                 got_live_update = False
         elif not self._update_event.is_set():
             try:
                 await asyncio.wait_for(self._update_event.wait(), timeout=0.25)
                 got_live_update = self._update_matches_selected(selected, identifier)
-            except TimeoutError:
+            except (TimeoutError, asyncio.TimeoutError):
                 got_live_update = False
 
         if not got_live_update:

--- a/tests/test_api_lifecycle.py
+++ b/tests/test_api_lifecycle.py
@@ -393,6 +393,36 @@ def test_connect_passes_configured_command_timeout_to_mqtt(monkeypatch) -> None:
     assert CapturingMQTT.last_response_timeout == 12.5
 
 
+def test_update_passes_optional_timeout_to_mqtt_ping() -> None:
+    """Per-call update timeout should be forwarded to MQTT ping."""
+    cloud = WorxCloud("user@example.com", "secret", "worx")
+    cloud._mowers_by_serial = {
+        "SN-1": {
+            "serial_number": "SN-1",
+            "uuid": "UUID-1",
+            "protocol": 0,
+            "mqtt_topics": {"command_in": "topic/in"},
+        }
+    }
+    calls: list[tuple[str, str, int, float | None]] = []
+
+    class MQTTStub:
+        async def aping(
+            self,
+            serial_number: str,
+            topic: str,
+            protocol: int,
+            timeout: float | None = None,
+        ) -> None:
+            calls.append((serial_number, topic, protocol, timeout))
+
+    cloud.mqtt = MQTTStub()
+
+    asyncio.run(cloud.update("SN-1", timeout=3.0))
+
+    assert calls == [("SN-1", "topic/in", 0, 3.0)]
+
+
 def test_async_context_manager_runs_lifecycle(monkeypatch) -> None:
     """async with should call authenticate/connect on enter and disconnect on exit."""
     cloud = WorxCloud("user@example.com", "secret", "worx")

--- a/tests/test_api_lifecycle.py
+++ b/tests/test_api_lifecycle.py
@@ -314,9 +314,9 @@ def test_fetch_prefers_newer_cfg_timestamp_over_older_existing_timestamp(
     asyncio.run(cloud._fetch())
 
     assert cloud.devices["Jim"].updated == datetime.fromisoformat(
-        "2026-03-13T00:24:23+01:00"
+        "2026-03-13T01:24:23+01:00"
     )
-    assert cloud.devices["Jim"].updated_origin == "cfg_tm"
+    assert cloud.devices["Jim"].updated_origin == "cfg_tm_utc"
 
 
 def test_token_updated_is_noop_without_mqtt() -> None:

--- a/tests/test_api_lifecycle.py
+++ b/tests/test_api_lifecycle.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import threading
 import warnings
 from datetime import datetime
 from typing import Any
@@ -73,6 +74,7 @@ class CapturingMQTT:
     """MQTT constructor stub capturing provided timeout."""
 
     last_response_timeout: float | None = None
+    constructor_thread_id: int | None = None
 
     def __init__(
         self,
@@ -89,6 +91,7 @@ class CapturingMQTT:
         self.identifier_resolver = identifier_resolver
         self.deduplicate_inflight_commands = deduplicate_inflight_commands
         self.__class__.last_response_timeout = response_timeout
+        self.__class__.constructor_thread_id = threading.get_ident()
 
     async def aconnect(self) -> None:
         return None
@@ -391,6 +394,35 @@ def test_connect_passes_configured_command_timeout_to_mqtt(monkeypatch) -> None:
 
     assert asyncio.run(cloud.connect()) is True
     assert CapturingMQTT.last_response_timeout == 12.5
+
+
+def test_connect_constructs_mqtt_off_event_loop_thread(monkeypatch) -> None:
+    """MQTT setup performs SSL work, so it should not run on the event loop thread."""
+    cloud = WorxCloud("user@example.com", "secret", "worx")
+    event_loop_thread_id: int | None = None
+
+    async def _fake_fetch() -> None:
+        nonlocal event_loop_thread_id
+        event_loop_thread_id = threading.get_ident()
+        cloud._mowers = [
+            {
+                "name": "My Mower",
+                "mqtt_endpoint": "mqtt.example.invalid",
+                "user_id": 99,
+                "mqtt_topics": {"command_out": "topic/out"},
+            }
+        ]
+        cloud.devices = {"My Mower": DummyDevice()}
+
+    CapturingMQTT.constructor_thread_id = None
+
+    monkeypatch.setattr(cloud, "_fetch", _fake_fetch)
+    monkeypatch.setattr("pyworxcloud.MQTT", CapturingMQTT)
+    monkeypatch.setattr("pyworxcloud.convert_to_time", lambda *_args, **_kwargs: None)
+
+    assert asyncio.run(cloud.connect()) is True
+    assert CapturingMQTT.constructor_thread_id is not None
+    assert CapturingMQTT.constructor_thread_id != event_loop_thread_id
 
 
 def test_update_passes_optional_timeout_to_mqtt_ping() -> None:

--- a/tests/test_dashboard_gui_worker.py
+++ b/tests/test_dashboard_gui_worker.py
@@ -2,13 +2,34 @@
 
 from __future__ import annotations
 
+import asyncio
 import queue
+from types import SimpleNamespace
 
 import pytest
 
 pytest.importorskip("tkinter")
 
 from test_dashboard_gui import CloudWorker, WorkerMessage
+from pyworxcloud.exceptions import TimeoutException
+
+
+def _device(name: str, serial: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        name=name,
+        serial_number=serial,
+        model="test-model",
+        online=True,
+        status=SimpleNamespace(description="idle"),
+        error=SimpleNamespace(description="none"),
+        battery=SimpleNamespace(percent=80),
+        locked=False,
+        firmware=SimpleNamespace(version="1.0"),
+        schedules={"next_schedule_start": None, "slots": []},
+        rainsensor=SimpleNamespace(triggered=False, remaining=0),
+        updated=None,
+        time_zone="UTC",
+    )
 
 
 def test_cloud_worker_shutdown_future_completes_before_loop_stop() -> None:
@@ -23,3 +44,65 @@ def test_cloud_worker_shutdown_future_completes_before_loop_stop() -> None:
         worker.stop()
 
     assert future.done() is True
+
+
+def test_refresh_falls_back_to_api_when_mqtt_command_times_out() -> None:
+    """Manual refresh should not surface MQTT command timeouts as dashboard errors."""
+
+    async def _run() -> queue.Queue[WorkerMessage]:
+        messages: queue.Queue[WorkerMessage] = queue.Queue()
+        initial_device = _device("Mower", "SN-1")
+        refreshed_device = _device("Mower", "SN-1")
+        refreshed_device.status.description = "api-refreshed"
+
+        class FakeCloud:
+            def __init__(self) -> None:
+                self.devices = {"Mower": initial_device}
+                self.update_calls: list[tuple[str, float | None]] = []
+                self.fetch_calls = 0
+
+            def get_mower(self, serial_number: str) -> dict:
+                assert serial_number == "SN-1"
+                return {
+                    "protocol": 0,
+                    "mqtt_topics": {"command_in": "topic/in"},
+                }
+
+            async def update(
+                self, serial_number: str, timeout: float | None = None
+            ) -> None:
+                self.update_calls.append((serial_number, timeout))
+                raise TimeoutException("refresh timed out")
+
+            async def _fetch(self) -> None:
+                self.fetch_calls += 1
+                self.devices["Mower"] = refreshed_device
+
+        cloud = FakeCloud()
+        worker = CloudWorker.__new__(CloudWorker)
+        worker._messages = messages
+        worker._cloud = cloud
+        worker._selected_name = "Mower"
+        worker._update_event = asyncio.Event()
+        worker._update_event_name = None
+
+        await worker.refresh("Mower")
+
+        assert cloud.update_calls == [("SN-1", 3.0)]
+        assert cloud.fetch_calls == 1
+        return messages
+
+    messages = asyncio.run(_run())
+    emitted = list(messages.queue)
+
+    assert any(
+        message.msg_type == "log"
+        and "running API fallback fetch" in str(message.payload.get("text"))
+        for message in emitted
+    )
+    assert any(
+        message.msg_type == "refresh_done"
+        and message.payload.get("source") == "api-fallback"
+        and message.payload.get("snapshot", {}).get("status") == "api-refreshed"
+        for message in emitted
+    )

--- a/tests/test_dashboard_gui_worker.py
+++ b/tests/test_dashboard_gui_worker.py
@@ -83,8 +83,10 @@ def test_refresh_falls_back_to_api_when_mqtt_command_times_out() -> None:
         worker._messages = messages
         worker._cloud = cloud
         worker._selected_name = "Mower"
+        worker._loop = asyncio.get_running_loop()
         worker._update_event = asyncio.Event()
         worker._update_event_name = None
+        worker._update_event_serial = None
 
         await worker.refresh("Mower")
 
@@ -104,5 +106,59 @@ def test_refresh_falls_back_to_api_when_mqtt_command_times_out() -> None:
         message.msg_type == "refresh_done"
         and message.payload.get("source") == "api-fallback"
         and message.payload.get("snapshot", {}).get("status") == "api-refreshed"
+        for message in emitted
+    )
+
+
+def test_refresh_matches_mqtt_update_by_serial_after_command_timeout() -> None:
+    """Manual refresh should accept a live update even when callback name differs."""
+
+    async def _run() -> tuple[queue.Queue[WorkerMessage], int]:
+        messages: queue.Queue[WorkerMessage] = queue.Queue()
+        device = _device("Mower", "SN-1")
+        fetch_calls = 0
+
+        class FakeCloud:
+            def __init__(self, worker: CloudWorker) -> None:
+                self.devices = {"Mower": device}
+                self._worker = worker
+
+            def get_mower(self, serial_number: str) -> dict:
+                assert serial_number == "SN-1"
+                return {
+                    "protocol": 0,
+                    "mqtt_topics": {"command_in": "topic/in"},
+                }
+
+            async def update(
+                self, serial_number: str, timeout: float | None = None
+            ) -> None:
+                assert (serial_number, timeout) == ("SN-1", 3.0)
+                self._worker._mark_update_received("Mower alias", "SN-1")
+                raise TimeoutException("refresh timed out")
+
+            async def _fetch(self) -> None:
+                nonlocal fetch_calls
+                fetch_calls += 1
+
+        worker = CloudWorker.__new__(CloudWorker)
+        worker._messages = messages
+        worker._selected_name = "Mower"
+        worker._loop = asyncio.get_running_loop()
+        worker._update_event = asyncio.Event()
+        worker._update_event_name = None
+        worker._update_event_serial = None
+        worker._cloud = FakeCloud(worker)
+
+        await worker.refresh("Mower")
+
+        return messages, fetch_calls
+
+    messages, fetch_calls = asyncio.run(_run())
+    emitted = list(messages.queue)
+
+    assert fetch_calls == 0
+    assert any(
+        message.msg_type == "refresh_done" and message.payload.get("source") == "mqtt"
         for message in emitted
     )

--- a/tests/test_dashboard_gui_worker.py
+++ b/tests/test_dashboard_gui_worker.py
@@ -1,0 +1,25 @@
+"""Tests for the manual GUI dashboard worker lifecycle."""
+
+from __future__ import annotations
+
+import queue
+
+import pytest
+
+pytest.importorskip("tkinter")
+
+from test_dashboard_gui import CloudWorker, WorkerMessage
+
+
+def test_cloud_worker_shutdown_future_completes_before_loop_stop() -> None:
+    """Shutdown should let run_coroutine_threadsafe futures complete."""
+    messages: queue.Queue[WorkerMessage] = queue.Queue()
+    worker = CloudWorker(messages)
+
+    future = worker.submit(worker.shutdown())
+    try:
+        future.result(timeout=1.0)
+    finally:
+        worker.stop()
+
+    assert future.done() is True

--- a/tests/test_device_decode.py
+++ b/tests/test_device_decode.py
@@ -322,7 +322,49 @@ def test_devicehandler_falls_back_to_cfg_date_time_when_dat_tm_is_missing(
     monkeypatch.setattr(devices_module, "datetime", FrozenDateTime)
     device = DeviceHandler(api=object(), mower=mower, tz="Europe/Copenhagen")
 
-    assert device.updated == datetime.fromisoformat("2026-03-11T12:00:00+01:00")
+    assert device.updated == datetime.fromisoformat("2026-03-11T13:00:00+01:00")
+
+
+def test_devicehandler_treats_cfg_date_time_as_utc_before_display_timezone(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """API cfg timestamps should not be interpreted in the host-local timezone."""
+    payload = {
+        "cfg": {
+            "id": 1,
+            "sn": "SERIAL-CFG-UTC",
+            "rd": 0,
+            "sc": {"d": [], "dd": False},
+            "tm": "09:03:31",
+            "dt": "05/05/2026",
+        },
+        "dat": {
+            "uuid": "UUID-CFG-UTC",
+            "mac": "AA:BB:CC:DD:EE:FF",
+            "conn": "online",
+            "ls": 1,
+            "le": 0,
+            "rain": {"s": 0, "cnt": 0},
+        },
+    }
+    mower = _build_mower(payload, 0, "CFG UTC Fixture")
+    mower["time_zone"] = "Europe/Copenhagen"
+
+    frozen_now = datetime.fromisoformat("2026-05-05T09:04:00+00:00")
+    real_datetime = devices_module.datetime
+
+    class FrozenDateTime(real_datetime):
+        @classmethod
+        def now(cls, tz=None):  # type: ignore[override]
+            if tz is None:
+                return frozen_now.replace(tzinfo=None)
+            return frozen_now.astimezone(tz)
+
+    monkeypatch.setattr(devices_module, "datetime", FrozenDateTime)
+    device = DeviceHandler(api=object(), mower=mower, tz=None)
+
+    assert device.updated == datetime.fromisoformat("2026-05-05T11:03:31+02:00")
+    assert device.updated_origin == "cfg_tm_utc"
 
 
 def test_devicehandler_rejects_implausible_future_cfg_timestamp(
@@ -375,7 +417,7 @@ def test_devicehandler_keeps_monotonic_updated_when_cfg_timestamp_goes_backwards
             "sn": "SERIAL-MONOTONIC",
             "rd": 0,
             "sc": {"d": [], "dd": False},
-            "tm": "17:24:22",
+            "tm": "15:24:22",
             "dt": "12/03/2026",
         },
         "dat": {
@@ -400,14 +442,14 @@ def test_devicehandler_keeps_monotonic_updated_when_cfg_timestamp_goes_backwards
 
     monkeypatch.setattr(devices_module, "datetime", FrozenDateTime)
     device = DeviceHandler(api=object(), mower=mower, tz="Europe/Copenhagen")
-    device.updated = FrozenDateTime.fromisoformat("2026-03-12T17:24:22+01:00")
+    device.updated = FrozenDateTime.fromisoformat("2026-03-12T16:24:22+01:00")
 
     regressing = json.loads(json.dumps(payload))
-    regressing["cfg"]["tm"] = "17:23:22"
+    regressing["cfg"]["tm"] = "15:23:22"
     regressing["cfg"]["id"] = 0
     device.raw_data = json.dumps(regressing)
 
-    assert device.updated == FrozenDateTime.fromisoformat("2026-03-12T17:24:22+01:00")
+    assert device.updated == FrozenDateTime.fromisoformat("2026-03-12T16:24:22+01:00")
 
 
 def test_devicehandler_uses_device_timezone_when_instance_timezone_is_missing() -> None:

--- a/tests/test_device_decode.py
+++ b/tests/test_device_decode.py
@@ -227,7 +227,7 @@ def test_devicehandler_updates_battery_cycle_current_from_live_nr() -> None:
 
 
 def test_devicehandler_prefers_dat_tm_over_cfg_date_time_for_updated() -> None:
-    """UTC dat.tm should win over cfg date/time when both are present."""
+    """UTC dat.tm should win and be represented in the effective timezone."""
     payload = {
         "cfg": {
             "id": 1,
@@ -253,6 +253,35 @@ def test_devicehandler_prefers_dat_tm_over_cfg_date_time_for_updated() -> None:
     device = DeviceHandler(api=object(), mower=mower, tz="UTC")
 
     assert device.updated == datetime.fromisoformat("2026-03-12T13:30:00+00:00")
+
+
+def test_devicehandler_converts_dat_tm_to_configured_timezone() -> None:
+    """Realtime UTC timestamps should not switch display timezone after MQTT updates."""
+    payload = {
+        "cfg": {
+            "id": 1,
+            "sn": "SERIAL-UPDATED-TZ",
+            "rd": 0,
+            "sc": {"d": [], "dd": False},
+            "tm": "21:30:00",
+            "dt": "12/03/2026",
+            "tz": "Australia/Perth",
+        },
+        "dat": {
+            "uuid": "UUID-UPDATED-TZ",
+            "mac": "AA:BB:CC:DD:EE:FF",
+            "conn": "online",
+            "ls": 1,
+            "le": 0,
+            "tm": "2026-03-12T13:30:00.000Z",
+            "rain": {"s": 0, "cnt": 0},
+        },
+    }
+    mower = _build_mower(payload, 0, "Updated TZ Fixture")
+
+    device = DeviceHandler(api=object(), mower=mower, tz="Europe/Copenhagen")
+
+    assert device.updated == datetime.fromisoformat("2026-03-12T14:30:00+01:00")
 
 
 def test_devicehandler_falls_back_to_cfg_date_time_when_dat_tm_is_missing(

--- a/tests/test_mqtt_commands.py
+++ b/tests/test_mqtt_commands.py
@@ -221,6 +221,95 @@ def test_publish_waits_for_matching_response(monkeypatch: pytest.MonkeyPatch) ->
     assert finished.is_set() is True
 
 
+def test_force_refresh_accepts_target_payload_with_different_message_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Force refresh should complete on the selected mower payload even with another id."""
+    mqtt, dummy = _build_mqtt(monkeypatch)
+    finished = threading.Event()
+    errors: list[Exception] = []
+
+    def _run_publish() -> None:
+        try:
+            mqtt.publish(
+                serial_number="SN-1",
+                topic="topic/in",
+                message={"cmd": 0},
+                protocol=0,
+                timeout=1.0,
+            )
+            finished.set()
+        except Exception as exc:  # pragma: no cover - defensive
+            errors.append(exc)
+
+    thread = threading.Thread(target=_run_publish)
+    thread.start()
+
+    deadline = time.time() + 1.0
+    while len(dummy.published) < 1 and time.time() < deadline:
+        time.sleep(0.01)
+    assert dummy.published
+
+    payload = json.loads(dummy.published[0]["payload"])
+    mqtt._on_message_received(
+        "topic/out",
+        json.dumps({"cfg": {"sn": "SN-1", "id": payload["id"] + 1}}).encode("utf-8"),
+    )
+
+    thread.join(timeout=1.0)
+    assert thread.is_alive() is False
+    assert errors == []
+    assert finished.is_set() is True
+
+
+def test_non_refresh_command_still_requires_matching_message_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Non-refresh commands should not complete on a mismatched response id."""
+    mqtt, dummy = _build_mqtt(monkeypatch)
+    finished = threading.Event()
+    errors: list[Exception] = []
+
+    def _run_publish() -> None:
+        try:
+            mqtt.publish(
+                serial_number="SN-1",
+                topic="topic/in",
+                message={"cmd": 1},
+                protocol=0,
+                timeout=1.0,
+            )
+            finished.set()
+        except Exception as exc:  # pragma: no cover - defensive
+            errors.append(exc)
+
+    thread = threading.Thread(target=_run_publish)
+    thread.start()
+
+    deadline = time.time() + 1.0
+    while len(dummy.published) < 1 and time.time() < deadline:
+        time.sleep(0.01)
+    assert dummy.published
+
+    payload = json.loads(dummy.published[0]["payload"])
+    mqtt._on_message_received(
+        "topic/out",
+        json.dumps({"cfg": {"sn": "SN-1", "id": payload["id"] + 1}}).encode("utf-8"),
+    )
+    time.sleep(0.05)
+    assert finished.is_set() is False
+
+    mqtt._on_message_received(
+        "topic/out",
+        json.dumps({"cfg": {"sn": "SN-1", "id": payload["id"]}}).encode("utf-8"),
+    )
+
+    thread.join(timeout=1.0)
+    assert thread.is_alive() is False
+    assert errors == []
+    assert finished.is_set() is True
+
+
 def test_publish_serializes_concurrent_commands(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_mqtt_commands.py
+++ b/tests/test_mqtt_commands.py
@@ -11,7 +11,7 @@ from typing import Any
 import pytest
 
 from pyworxcloud.exceptions import TimeoutException
-from pyworxcloud.utils.mqtt import MQTT
+from pyworxcloud.utils.mqtt import MQTT, _wait_for_operation
 
 
 class _ImmediateFuture:
@@ -37,6 +37,17 @@ class _DummyClient:
         event.set()
         self.publish_events.append(event)
         return _ImmediateFuture(), 1
+
+
+class _PahoPublishInfo:
+    """Paho-like publish info stub."""
+
+    def __init__(self, wait_result: bool | None, rc: int = 0) -> None:
+        self.wait_result = wait_result
+        self.rc = rc
+
+    def wait_for_publish(self, timeout: float | None = None) -> bool | None:
+        return self.wait_result
 
 
 def _build_mqtt(
@@ -84,6 +95,17 @@ def test_publish_times_out_when_no_response(
     assert "identifier_type=sn" in caplog.text
     assert "protocol=0" in caplog.text
     assert "topic=topic/in" in caplog.text
+
+
+def test_wait_for_operation_accepts_paho_publish_none_success() -> None:
+    """Paho publish wait may return None on success."""
+    _wait_for_operation(_PahoPublishInfo(wait_result=None))
+
+
+def test_wait_for_operation_rejects_paho_publish_false_timeout() -> None:
+    """Paho publish wait should only timeout on explicit False."""
+    with pytest.raises(TimeoutError, match="timed out after 0.1"):
+        _wait_for_operation(_PahoPublishInfo(wait_result=False), timeout=0.1)
 
 
 def test_publish_uses_default_response_timeout(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_mqtt_commands.py
+++ b/tests/test_mqtt_commands.py
@@ -6,6 +6,7 @@ import json
 import logging
 import threading
 import time
+from concurrent.futures import TimeoutError as FutureTimeoutError
 from typing import Any
 
 import pytest
@@ -104,7 +105,7 @@ def test_wait_for_operation_accepts_paho_publish_none_success() -> None:
 
 def test_wait_for_operation_rejects_paho_publish_false_timeout() -> None:
     """Paho publish wait should only timeout on explicit False."""
-    with pytest.raises(TimeoutError, match="timed out after 0.1"):
+    with pytest.raises(FutureTimeoutError, match="timed out after 0.1"):
         _wait_for_operation(_PahoPublishInfo(wait_result=False), timeout=0.1)
 
 

--- a/tests/test_mqtt_lifecycle.py
+++ b/tests/test_mqtt_lifecycle.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import threading
+import time
 from concurrent.futures import TimeoutError as FutureTimeoutError
 from typing import Any
 
@@ -112,6 +113,30 @@ def test_disconnect_releases_pending_command_waiter() -> None:
     assert mqtt._pending_response_message_id is None
     assert mqtt._pending_response_accepts_any_message_id is False
     assert mqtt._pending_command_signature is None
+
+
+def test_disconnect_does_not_hang_when_loop_stop_blocks() -> None:
+    """Disconnect should not wait forever for paho loop_stop."""
+    loop_stop_started = threading.Event()
+    release_loop_stop = threading.Event()
+
+    class BlockingLoopStopClient(_ClientStub):
+        def loop_stop(self) -> None:
+            loop_stop_started.set()
+            release_loop_stop.wait()
+
+    mqtt = _build_mqtt_lifecycle_fixture(client=BlockingLoopStopClient())
+
+    started = time.perf_counter()
+    try:
+        mqtt.disconnect()
+    finally:
+        release_loop_stop.set()
+
+    assert loop_stop_started.is_set() is True
+    assert time.perf_counter() - started < 1.0
+    assert mqtt._connection_future is None
+    assert mqtt._is_connected is False
 
 
 def test_shutdown_is_idempotent_and_detaches_resources() -> None:

--- a/tests/test_mqtt_lifecycle.py
+++ b/tests/test_mqtt_lifecycle.py
@@ -49,7 +49,14 @@ def _build_mqtt_lifecycle_fixture(
     mqtt._is_connected = connected
     mqtt._connection_future = object()
     mqtt._shutdown_timeout = 5.0
+    mqtt._disconnect_timeout = 5.0
     mqtt._topic = ["topic/out"]
+    mqtt._response_lock = threading.Lock()
+    mqtt._response_event = threading.Event()
+    mqtt._pending_response_target = None
+    mqtt._pending_response_message_id = None
+    mqtt._pending_response_accepts_any_message_id = False
+    mqtt._pending_command_signature = None
     mqtt.client = client
     return mqtt
 
@@ -88,6 +95,23 @@ def test_disconnect_swallows_disconnect_future_timeout() -> None:
     assert client.disconnect_calls == 1
     assert mqtt._connection_future is None
     assert mqtt._is_connected is False
+
+
+def test_disconnect_releases_pending_command_waiter() -> None:
+    """Disconnect should wake command waits so shutdown is not delayed by timeout."""
+    mqtt = _build_mqtt_lifecycle_fixture(client=_ClientStub())
+    mqtt._pending_response_target = "SN-1"
+    mqtt._pending_response_message_id = 1234
+    mqtt._pending_response_accepts_any_message_id = True
+    mqtt._pending_command_signature = ("SN-1", "topic/in", 0, "{}")
+
+    mqtt.disconnect()
+
+    assert mqtt._response_event.is_set() is True
+    assert mqtt._pending_response_target is None
+    assert mqtt._pending_response_message_id is None
+    assert mqtt._pending_response_accepts_any_message_id is False
+    assert mqtt._pending_command_signature is None
 
 
 def test_shutdown_is_idempotent_and_detaches_resources() -> None:

--- a/tests/test_mqtt_lifecycle.py
+++ b/tests/test_mqtt_lifecycle.py
@@ -7,10 +7,7 @@ import threading
 from concurrent.futures import TimeoutError as FutureTimeoutError
 from typing import Any
 
-import awscrt.mqtt
-import pytest
-
-from pyworxcloud.utils.mqtt import MQTT, _connect_with_awscrt_compat
+from pyworxcloud.utils.mqtt import MQTT, MQTT_CONNECT_ACCEPTED
 
 
 class _ImmediateFuture:
@@ -42,38 +39,6 @@ class _ClientStub:
         return self.future
 
 
-class _ConnectMismatchClientStub:
-    """Client stub that reproduces the awscrt 17/18-arg connect mismatch."""
-
-    def connect(self) -> None:
-        raise TypeError("function takes exactly 18 arguments (17 given)")
-
-
-class _ConnectTypeErrorClientStub:
-    """Client stub that raises an unrelated TypeError."""
-
-    def connect(self) -> None:
-        raise TypeError("some other type error")
-
-
-class _ShutdownEventStub:
-    """Stub exposing a wait() method used by AWS CRT resources."""
-
-    def __init__(self) -> None:
-        self.wait_calls = 0
-
-    def wait(self, _timeout: float) -> bool:
-        self.wait_calls += 1
-        return True
-
-
-class _ShutdownResourceStub:
-    """Resource stub with shutdown_event attribute."""
-
-    def __init__(self) -> None:
-        self.shutdown_event = _ShutdownEventStub()
-
-
 def _build_mqtt_lifecycle_fixture(
     *, connected: bool = True, client: Any | None = None
 ) -> MQTT:
@@ -86,9 +51,6 @@ def _build_mqtt_lifecycle_fixture(
     mqtt._shutdown_timeout = 5.0
     mqtt._topic = ["topic/out"]
     mqtt.client = client
-    mqtt._host_resolver = _ShutdownResourceStub()
-    mqtt._client_bootstrap = _ShutdownResourceStub()
-    mqtt._event_loop_group = _ShutdownResourceStub()
     return mqtt
 
 
@@ -129,7 +91,7 @@ def test_disconnect_swallows_disconnect_future_timeout() -> None:
 
 
 def test_shutdown_is_idempotent_and_detaches_resources() -> None:
-    """Shutdown should execute cleanup once and detach all AWS CRT resources."""
+    """Shutdown should execute cleanup once and detach the paho client."""
     client = _ClientStub()
     mqtt = _build_mqtt_lifecycle_fixture(client=client)
 
@@ -139,9 +101,6 @@ def test_shutdown_is_idempotent_and_detaches_resources() -> None:
     assert client.disconnect_calls == 1
     assert mqtt.client is None
     assert mqtt._connection_future is None
-    assert mqtt._host_resolver is None
-    assert mqtt._client_bootstrap is None
-    assert mqtt._event_loop_group is None
     assert mqtt._shutdown_event is True
     assert mqtt._is_connected is False
 
@@ -157,23 +116,6 @@ def test_shutdown_skips_second_disconnect_after_prior_disconnect() -> None:
     assert client.disconnect_calls == 1
 
 
-def test_shutdown_waits_for_resource_shutdown_events() -> None:
-    """Shutdown should give CRT resources a bounded chance to tear down cleanly."""
-    client = _ClientStub()
-    mqtt = _build_mqtt_lifecycle_fixture(client=client)
-    host_resolver = mqtt._host_resolver
-    client_bootstrap = mqtt._client_bootstrap
-    event_loop_group = mqtt._event_loop_group
-
-    mqtt.shutdown()
-
-    assert (
-        host_resolver.shutdown_event.wait_calls,
-        client_bootstrap.shutdown_event.wait_calls,
-        event_loop_group.shutdown_event.wait_calls,
-    ) == (1, 1, 1)
-
-
 def test_shutdown_swallows_disconnect_future_timeout() -> None:
     """Shutdown should not block indefinitely on disconnect futures."""
     client = _ClientStub()
@@ -186,39 +128,6 @@ def test_shutdown_swallows_disconnect_future_timeout() -> None:
     assert mqtt._shutdown_event is True
 
 
-def test_connect_with_awscrt_compat_retries_known_arg_mismatch(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Known mixed awscrt installs should use the legacy compatibility path."""
-    fallback_future = _ImmediateFuture()
-    fallback_calls: list[Any] = []
-
-    def _legacy(client: Any) -> _ImmediateFuture:
-        fallback_calls.append(client)
-        return fallback_future
-
-    monkeypatch.setattr(
-        "pyworxcloud.utils.mqtt._legacy_connect_without_metrics", _legacy
-    )
-
-    result = _connect_with_awscrt_compat(
-        _ConnectMismatchClientStub(),
-        logging.getLogger("test"),
-    )
-
-    assert result is fallback_future
-    assert len(fallback_calls) == 1
-
-
-def test_connect_with_awscrt_compat_preserves_unrelated_type_errors() -> None:
-    """Only the known awscrt mismatch should trigger the compatibility path."""
-    with pytest.raises(TypeError, match="some other type error"):
-        _connect_with_awscrt_compat(
-            _ConnectTypeErrorClientStub(),
-            logging.getLogger("test"),
-        )
-
-
 def test_connection_resumed_resubscribes_even_when_session_persists() -> None:
     """Resume should trigger a full reconnect even when session_present is true."""
     mqtt = _build_mqtt_lifecycle_fixture(connected=False, client=_ClientStub())
@@ -229,7 +138,7 @@ def test_connection_resumed_resubscribes_even_when_session_persists() -> None:
 
     mqtt._on_connection_resumed(
         None,
-        awscrt.mqtt.ConnectReturnCode.ACCEPTED,
+        MQTT_CONNECT_ACCEPTED,
         True,
     )
 
@@ -249,7 +158,7 @@ def test_connection_resumed_resubscribes_when_session_is_not_present() -> None:
 
     mqtt._on_connection_resumed(
         None,
-        awscrt.mqtt.ConnectReturnCode.ACCEPTED,
+        MQTT_CONNECT_ACCEPTED,
         False,
     )
 

--- a/tests/test_mqtt_runtime.py
+++ b/tests/test_mqtt_runtime.py
@@ -6,12 +6,11 @@ import logging
 import threading
 import time
 
-import awscrt.mqtt
 import pytest
 
 from pyworxcloud.events import EventHandler
 from pyworxcloud.exceptions import TimeoutException
-from pyworxcloud.utils.mqtt import MQTT
+from pyworxcloud.utils.mqtt import MQTT, MQTT_CONNECT_ACCEPTED
 
 
 def _build_mqtt() -> MQTT:
@@ -45,7 +44,7 @@ def test_connection_resumed_ignores_stale_generation() -> None:
 
     mqtt._on_connection_resumed(
         object(),
-        awscrt.mqtt.ConnectReturnCode.ACCEPTED,
+        MQTT_CONNECT_ACCEPTED,
         True,
         generation=1,
     )
@@ -63,7 +62,7 @@ def test_connection_resumed_marks_active_generation_ready() -> None:
 
     mqtt._on_connection_resumed(
         object(),
-        awscrt.mqtt.ConnectReturnCode.ACCEPTED,
+        MQTT_CONNECT_ACCEPTED,
         True,
         generation=2,
     )


### PR DESCRIPTION
## Summary

Switches the MQTT transport implementation from AWS IoT Device SDK / AWS CRT to paho-mqtt while keeping the existing public MQTT interface intact.

## Changes

- Replaced AWS IoT SDK connection setup with a paho-mqtt WebSocket client using the existing JWT custom-authorizer username format.
- Preserved connect/disconnect/shutdown, publish/subscribe, token refresh, response matching, timeout, callback, and dedupe behavior.
- Updated MQTT lifecycle/runtime tests to use paho-compatible constants instead of AWS CRT imports.
- Replaced the `awsiotsdk` dependency with `paho-mqtt` and refreshed `poetry.lock`.

## Testing

- `ruff format`
- `ruff check`
- `pytest tests/test_mqtt_commands.py tests/test_mqtt_lifecycle.py tests/test_mqtt_runtime.py` — 23 passed
- `pytest` — 134 passed

## Notes

Suggested semver label: `minor` (dependency/runtime implementation change without intended public API break). Label was not set and should be approved before merge.
