### PR TITLE
Fix border cut settings payload flag

### DIFF
--- a/pyworxcloud/__init__.py
+++ b/pyworxcloud/__init__.py
@@ -968,7 +968,7 @@ class WorxCloud(dict):
             raise ValueError("Unable to determine border-cut settings payload")
 
         return {
-            "s": [{"id": 1, "c": True, "cfg": {"cut": cut_payload}}],
+            "s": [{"id": 1, "c": 1, "cfg": {"cut": cut_payload}}],
             "p": [],
         }
 

--- a/tests/test_api_lifecycle.py
+++ b/tests/test_api_lifecycle.py
@@ -2589,13 +2589,13 @@ def test_dedicated_border_cut_setting_helpers_publish_single_setting() -> None:
 
     assert mqtt.calls[0]["message"] == {
         "mz": {
-            "s": [{"id": 1, "c": True, "cfg": {"cut": {"ob": 0}}}],
+            "s": [{"id": 1, "c": 1, "cfg": {"cut": {"ob": 0}}}],
             "p": [],
         }
     }
     assert mqtt.calls[1]["message"] == {
         "mz": {
-            "s": [{"id": 1, "c": True, "cfg": {"cut": {"bd": 150}}}],
+            "s": [{"id": 1, "c": 1, "cfg": {"cut": {"bd": 150}}}],
             "p": [],
         }
     }


### PR DESCRIPTION
Summary
Fix the protocol 1 border-cut settings payload so the scheduler command flag is sent as the observed integer value instead of a boolean.

Changes
- Send `c: 1` in border-cut settings mz payloads.
- Update the dedicated border-cut helper test expectations to cover the integer flag.

Testing
- `ruff format`
- `ruff check`
- `poetry run pytest tests/test_api_lifecycle.py -k border_cut`

Notes
- Proposed semver label: `patch`.