### PR TITLE
Fix Vision border cut settings command

### DIFF
--- a/pyworxcloud/__init__.py
+++ b/pyworxcloud/__init__.py
@@ -2008,6 +2008,20 @@ class WorxCloud(dict):
 
         await self._schedule_api_refresh()
 
+    async def set_border_cut_settings(
+        self,
+        serial_number: str,
+        *,
+        cut_over_border: bool,
+        border_distance: int,
+    ) -> None:
+        """Persist both protocol 1 border-cut settings in one command."""
+        await self._set_border_cut_settings(
+            serial_number,
+            cut_over_border=cut_over_border,
+            border_distance=border_distance,
+        )
+
     async def set_cut_over_border(
         self, serial_number: str, cut_over_border: bool
     ) -> None:

--- a/tests/test_api_lifecycle.py
+++ b/tests/test_api_lifecycle.py
@@ -2546,6 +2546,67 @@ def test_schedule_crud_publishes_normalized_payload_and_refreshes() -> None:
     assert refreshes == [False, False, False, False]
 
 
+def test_border_cut_settings_helper_publishes_combined_settings() -> None:
+    """Border-cut settings helper should publish both settings in one command."""
+    cloud = WorxCloud("user@example.com", "secret", "worx")
+    mqtt = RecordingMQTT()
+    cloud.mqtt = mqtt
+    cloud._mowers = [
+        {
+            "name": "Vision",
+            "serial_number": "SERIAL-1",
+            "uuid": "UUID-1",
+            "mac_address": "MAC-1",
+            "model": {"friendly_name": "Vision", "code": "WR206E"},
+            "time_zone": "UTC",
+            "warranty_expires_at": None,
+            "warranty_registered": False,
+            "online": True,
+            "protocol": 1,
+            "mqtt_topics": {"command_in": "topic/p1", "command_out": "topic/out/p1"},
+            "capabilities": ["one_time_scheduler"],
+            "last_status": {
+                "payload": {
+                    "cfg": {
+                        "id": 0,
+                        "cut": {"b": 0, "bd": 50, "ob": 1, "z": []},
+                        "sc": {
+                            "enabled": 1,
+                            "paused": 0,
+                            "once": {"time": 30, "cfg": {"cut": {"b": 0, "z": []}}},
+                            "slots": [],
+                        },
+                    },
+                    "dat": {"uuid": "UUID-1", "ls": 1, "le": 0, "rain": {"s": 0}},
+                }
+            },
+        }
+    ]
+    cloud._rebuild_mower_indices()
+
+    asyncio.run(
+        cloud.set_border_cut_settings(
+            "SERIAL-1",
+            cut_over_border=False,
+            border_distance=150,
+        )
+    )
+
+    assert mqtt.calls == [
+        {
+            "serial": "UUID-1",
+            "topic": "topic/p1",
+            "message": {
+                "mz": {
+                    "s": [{"id": 1, "c": 1, "cfg": {"cut": {"ob": 0, "bd": 150}}}],
+                    "p": [],
+                }
+            },
+            "protocol": 1,
+        }
+    ]
+
+
 def test_dedicated_border_cut_setting_helpers_publish_single_setting() -> None:
     """Dedicated border-cut helpers should publish one setting at a time."""
     cloud = WorxCloud("user@example.com", "secret", "worx")


### PR DESCRIPTION
## Description
Expose a public `set_border_cut_settings` helper that sends `cut_over_border` and `border_distance` together in one border-cut settings command. Vision firmware can silently ignore partial `cut` updates, so callers need a combined helper instead of issuing separate setting updates.

## Test strategy
- `ruff format`
- `ruff check --fix`
- `pytest tests/test_api_lifecycle.py -k border_cut_setting`

## Known limitations
No physical mower validation was performed; behavior is covered with the existing MQTT publish test harness and based on the payload behavior reported in MTrab/landroid_cloud#876.

## Required configuration changes
None.

## Semver
Proposed label: patch

Fixes MTrab/landroid_cloud#876