### PR TITLE
Fix border cut settings payload shape

### DIFF
--- a/pyworxcloud/__init__.py
+++ b/pyworxcloud/__init__.py
@@ -957,7 +957,7 @@ class WorxCloud(dict):
         cut_over_border: bool | None = None,
         border_distance: int | None = None,
     ) -> dict[str, Any]:
-        """Build the observed protocol 1 mz payload for persistent border-cut settings."""
+        """Build the observed protocol 1 cut payload for border-cut settings."""
         cut_payload: dict[str, int] = {}
         if cut_over_border is not None:
             cut_payload["ob"] = int(cut_over_border)
@@ -967,10 +967,7 @@ class WorxCloud(dict):
         if not cut_payload:
             raise ValueError("Unable to determine border-cut settings payload")
 
-        return {
-            "s": [{"id": 1, "c": 1, "cfg": {"cut": cut_payload}}],
-            "p": [],
-        }
+        return cut_payload
 
     def _build_schedule_model(self, mower: dict[str, Any]) -> ScheduleModel:
         """Build a normalized schedule model from the mower cache."""
@@ -1978,14 +1975,14 @@ class WorxCloud(dict):
                 "This device does not support border-cut settings"
             )
 
-        mz_payload = self._build_border_cut_settings_payload(
+        cut_payload = self._build_border_cut_settings_payload(
             cut_over_border=cut_over_border,
             border_distance=border_distance,
         )
         await self.mqtt.apublish(
             mower["uuid"],
             mower["mqtt_topics"]["command_in"],
-            {"mz": mz_payload},
+            {"cut": cut_payload},
             mower["protocol"],
         )
 
@@ -1995,13 +1992,14 @@ class WorxCloud(dict):
             if isinstance(payload, dict):
                 cfg = payload.setdefault("cfg", {})
                 if isinstance(cfg, dict):
-                    cfg["mz"] = self._clone_dict(mz_payload)
                     top_level_cut = cfg.get("cut")
                     if isinstance(top_level_cut, dict):
                         if cut_over_border is not None:
                             top_level_cut["ob"] = int(cut_over_border)
                         if border_distance is not None:
                             top_level_cut["bd"] = border_distance
+                    else:
+                        cfg["cut"] = self._clone_dict(cut_payload)
                     device_handler = self.devices.get(mower["name"])
                     if device_handler is not None:
                         device_handler.raw_data = json.dumps(payload)

--- a/tests/test_api_lifecycle.py
+++ b/tests/test_api_lifecycle.py
@@ -2596,12 +2596,7 @@ def test_border_cut_settings_helper_publishes_combined_settings() -> None:
         {
             "serial": "UUID-1",
             "topic": "topic/p1",
-            "message": {
-                "mz": {
-                    "s": [{"id": 1, "c": 1, "cfg": {"cut": {"ob": 0, "bd": 150}}}],
-                    "p": [],
-                }
-            },
+            "message": {"cut": {"ob": 0, "bd": 150}},
             "protocol": 1,
         }
     ]
@@ -2648,18 +2643,8 @@ def test_dedicated_border_cut_setting_helpers_publish_single_setting() -> None:
     asyncio.run(cloud.set_cut_over_border("SERIAL-1", False))
     asyncio.run(cloud.set_border_distance("SERIAL-1", 150))
 
-    assert mqtt.calls[0]["message"] == {
-        "mz": {
-            "s": [{"id": 1, "c": 1, "cfg": {"cut": {"ob": 0}}}],
-            "p": [],
-        }
-    }
-    assert mqtt.calls[1]["message"] == {
-        "mz": {
-            "s": [{"id": 1, "c": 1, "cfg": {"cut": {"bd": 150}}}],
-            "p": [],
-        }
-    }
+    assert mqtt.calls[0]["message"] == {"cut": {"ob": 0}}
+    assert mqtt.calls[1]["message"] == {"cut": {"bd": 150}}
 
 
 def test_dedicated_border_cut_setting_helpers_reject_invalid_inputs() -> None:


### PR DESCRIPTION
## Description
Send Vision border-cut settings as the tested top-level `cut` payload instead of wrapping them in an `mz` payload. The previous combined helper correctly sent `bd` and `ob` together, but also included `mz.p = []`, which can be interpreted as clearing zone data.

## Test strategy
- `ruff format`
- `ruff check --fix`
- `pytest tests/test_api_lifecycle.py -k border_cut_setting`

## Known limitations
No physical mower validation was performed; the change follows the payload shape reported as working in MTrab/landroid_cloud#876.

## Required configuration changes
None.

## Semver
Proposed label: patch

Refs MTrab/landroid_cloud#876