### PR TITLE
Redact account email addresses in auth logs

### DIFF
--- a/pyworxcloud/__init__.py
+++ b/pyworxcloud/__init__.py
@@ -41,7 +41,7 @@ from .exceptions import (
     ZoneNoProbability,
     ZoneNotDefined,
 )
-from .helpers import convert_to_time, get_logger
+from .helpers import convert_to_time, get_logger, redact_email_address
 from .utils import MQTT, DeviceCapability, DeviceHandler, ScheduleEntry, ScheduleModel
 from .utils.lawn import Lawn
 from .utils.mqtt import Command
@@ -247,7 +247,8 @@ class WorxCloud(dict):
 
     async def authenticate(self) -> bool:
         """Authenticate against the API."""
-        self._log.debug("Authenticating %s", self._username)
+        redacted_username = redact_email_address(self._username)
+        self._log.debug("Authenticating %s", redacted_username)
 
         try:
             await self._api.get_token()
@@ -257,11 +258,11 @@ class WorxCloud(dict):
         auth = self._api.authenticate()
         if auth is False:
             self._auth_result = False
-            self._log.debug("Authentication for %s failed!", self._username)
+            self._log.debug("Authentication for %s failed!", redacted_username)
             raise AuthorizationError("Unauthorized")
 
         self._auth_result = True
-        self._log.debug("Authentication for %s successful", self._username)
+        self._log.debug("Authentication for %s successful", redacted_username)
 
         return True
 

--- a/pyworxcloud/helpers/__init__.py
+++ b/pyworxcloud/helpers/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from .logger import get_logger
+from .logger import get_logger, redact_email_address
 from .time_format import convert_to_time, string_to_time
 
-__all__ = [convert_to_time, get_logger, string_to_time]
+__all__ = [convert_to_time, get_logger, redact_email_address, string_to_time]

--- a/pyworxcloud/helpers/logger.py
+++ b/pyworxcloud/helpers/logger.py
@@ -7,6 +7,30 @@ import logging
 PACKAGE_LOGGER_NAME = "pyworxcloud"
 
 
+def redact_email_address(value: str) -> str:
+    """Return a log-safe representation of an email address."""
+    if "@" not in value:
+        return "[REDACTED]"
+
+    local_part, domain = value.split("@", 1)
+    domain_labels = domain.split(".")
+    redacted_domain = ".".join(
+        _redact_email_part(label) if index == 0 else label
+        for index, label in enumerate(domain_labels)
+    )
+
+    return f"{_redact_email_part(local_part)}@{redacted_domain}"
+
+
+def _redact_email_part(value: str) -> str:
+    """Redact the middle of one email address part."""
+    if not value:
+        return "[REDACTED]"
+    if len(value) == 1:
+        return f"{value}[REDACTED]"
+    return f"{value[0]}[REDACTED]{value[-1]}"
+
+
 def get_logger(name: str) -> logging.Logger:
     """Return a standard library logger for this package."""
 

--- a/tests/test_api_lifecycle.py
+++ b/tests/test_api_lifecycle.py
@@ -15,11 +15,16 @@ from pyworxcloud.api import LandroidCloudAPI
 from pyworxcloud.clouds import CloudType
 from pyworxcloud.events import LandroidEvent
 from pyworxcloud.exceptions import (
+    AuthorizationError,
     NoFirmwareAvailableError,
     NoFirmwareOtaError,
     NotFoundError,
 )
-from pyworxcloud.helpers.logger import PACKAGE_LOGGER_NAME, get_logger
+from pyworxcloud.helpers.logger import (
+    PACKAGE_LOGGER_NAME,
+    get_logger,
+    redact_email_address,
+)
 from pyworxcloud.utils.schedule_codec import ScheduleEntry, ScheduleModel
 
 
@@ -370,6 +375,58 @@ def test_get_logger_does_not_accumulate_handlers() -> None:
         package_logger.setLevel(original_level)
         for handler in original_handlers:
             package_logger.addHandler(handler)
+
+
+@pytest.mark.parametrize(
+    ("email", "expected"),
+    [
+        ("alice@example.com", "a[REDACTED]e@e[REDACTED]e.com"),
+        ("a@example.com", "a[REDACTED]@e[REDACTED]e.com"),
+        ("not-an-email", "[REDACTED]"),
+    ],
+)
+def test_redact_email_address_masks_log_values(email: str, expected: str) -> None:
+    """Email addresses should be masked before being written to logs."""
+    assert redact_email_address(email) == expected
+
+
+def test_authenticate_logs_redacted_email(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Authentication logs should not expose the full account email."""
+    cloud = WorxCloud("alice@example.com", "secret", "worx")
+
+    async def _get_token() -> None:
+        return None
+
+    monkeypatch.setattr(cloud._api, "get_token", _get_token)
+    monkeypatch.setattr(cloud._api, "authenticate", lambda: True)
+
+    with caplog.at_level("DEBUG", logger="pyworxcloud"):
+        asyncio.run(cloud.authenticate())
+
+    assert "alice@example.com" not in caplog.text
+    assert "a[REDACTED]e@e[REDACTED]e.com" in caplog.text
+
+
+def test_authenticate_failure_logs_redacted_email(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Failed authentication logs should not expose the full account email."""
+    cloud = WorxCloud("alice@example.com", "secret", "worx")
+
+    async def _get_token() -> None:
+        return None
+
+    monkeypatch.setattr(cloud._api, "get_token", _get_token)
+    monkeypatch.setattr(cloud._api, "authenticate", lambda: False)
+
+    with caplog.at_level("DEBUG", logger="pyworxcloud"):
+        with pytest.raises(AuthorizationError):
+            asyncio.run(cloud.authenticate())
+
+    assert "alice@example.com" not in caplog.text
+    assert "a[REDACTED]e@e[REDACTED]e.com" in caplog.text
 
 
 def test_on_api_update_dispatches_api_event_callback() -> None:


### PR DESCRIPTION
## Description
Redacts account email addresses before writing authentication debug logs. This keeps auth start, success, and failure messages useful for troubleshooting without exposing the full user email address in copied debug logs.

Fixes MTrab/landroid_cloud#1243

## Test strategy
- `python -m ruff format pyworxcloud tests`
- `python -m ruff check pyworxcloud tests`
- `python -m pytest -q`

## Known limitations
The full pytest run still emits an existing `Unclosed client session` warning after completion, but the suite passes.

## Required configuration changes
None.

## Semver
Proposed semver label: `patch`. This has not been applied yet and should be verified before labeling/merge.
