### PR TITLE
Fix Vision border-cut: build mz payload from cached zones (keep zones/topology)

### DIFF
--- a/pyworxcloud/__init__.py
+++ b/pyworxcloud/__init__.py
@@ -1066,6 +1066,42 @@ class WorxCloud(dict):
 
         return cut_payload
 
+    def _border_cut_command(
+        self, mower: dict[str, Any], cut_payload: dict[str, int]
+    ) -> dict[str, Any]:
+        """Return the border-cut MQTT command for a mower.
+
+        Border-cut is a per-zone setting (``cfg.mz.s[*].cfg.cut``) and the zone
+        topology is stored separately in ``cfg.mz.p``. Build the command from
+        the mower's cached multizone config so existing zones and their
+        topology are preserved and only the cut values change. Fall back to the
+        top-level ``cut`` form when no multizone config is cached.
+
+        Sending a single hard-coded zone with an empty ``p`` (the previous
+        behaviour) makes the mower drop the other zones and the beacon mapping.
+        """
+        last_status = mower.get("last_status")
+        if isinstance(last_status, dict):
+            payload = last_status.get("payload")
+            if isinstance(payload, dict):
+                cfg = payload.get("cfg")
+                if isinstance(cfg, dict):
+                    current_mz = cfg.get("mz")
+                    if (
+                        isinstance(current_mz, dict)
+                        and isinstance(current_mz.get("s"), list)
+                        and current_mz["s"]
+                    ):
+                        mz = self._clone_dict(current_mz)
+                        for zone in mz["s"]:
+                            if isinstance(zone, dict):
+                                zone_cut = zone.setdefault("cfg", {}).setdefault(
+                                    "cut", {}
+                                )
+                                zone_cut.update(cut_payload)
+                        return {"mz": mz}
+        return {"cut": cut_payload}
+
     def _build_schedule_model(self, mower: dict[str, Any]) -> ScheduleModel:
         """Build a normalized schedule model from the mower cache."""
         return schedule_model_from_payload(
@@ -2076,10 +2112,11 @@ class WorxCloud(dict):
             cut_over_border=cut_over_border,
             border_distance=border_distance,
         )
+        command = self._border_cut_command(mower, cut_payload)
         await self._mqtt_apublish(
             mower["uuid"],
             mower["mqtt_topics"]["command_in"],
-            {"cut": cut_payload},
+            command,
             mower["protocol"],
         )
 

--- a/tests/test_api_lifecycle.py
+++ b/tests/test_api_lifecycle.py
@@ -2752,6 +2752,75 @@ def test_border_cut_settings_helper_publishes_combined_settings() -> None:
     ]
 
 
+def test_border_cut_settings_preserves_zones_via_mz() -> None:
+    """With a cached multizone config, border-cut updates the cut value on each
+    zone while keeping every zone (mz.s) and the zone topology (mz.p) intact."""
+    cloud = WorxCloud("user@example.com", "secret", "worx")
+    mqtt = RecordingMQTT()
+    cloud.mqtt = mqtt
+    cloud._mowers = [
+        {
+            "name": "Vision",
+            "serial_number": "SERIAL-1",
+            "uuid": "UUID-1",
+            "mac_address": "MAC-1",
+            "model": {"friendly_name": "Vision", "code": "WR206E"},
+            "time_zone": "UTC",
+            "warranty_expires_at": None,
+            "warranty_registered": False,
+            "online": True,
+            "protocol": 1,
+            "mqtt_topics": {"command_in": "topic/p1", "command_out": "topic/out/p1"},
+            "capabilities": ["one_time_scheduler"],
+            "last_status": {
+                "payload": {
+                    "cfg": {
+                        "id": 0,
+                        "mz": {
+                            "s": [
+                                {"id": 1, "c": 1, "cfg": {"cut": {"ob": 1, "bd": 100}}},
+                                {"id": 2, "c": 0, "cfg": {"cut": {"ob": 0, "bd": 200}}},
+                            ],
+                            "p": [
+                                {"z1": 1, "z2": 2, "t1": "BEACON-1", "t2": "BEACON-2"}
+                            ],
+                        },
+                        "sc": {
+                            "enabled": 1,
+                            "paused": 0,
+                            "once": {"time": 30, "cfg": {"cut": {"b": 0, "z": []}}},
+                            "slots": [],
+                        },
+                    },
+                    "dat": {"uuid": "UUID-1"},
+                }
+            },
+        }
+    ]
+    cloud._rebuild_mower_indices()
+
+    asyncio.run(
+        cloud.set_border_cut_settings(
+            "SERIAL-1",
+            cut_over_border=True,
+            border_distance=150,
+        )
+    )
+
+    assert len(mqtt.calls) == 1
+    message = mqtt.calls[0]["message"]
+    assert "cut" not in message
+    mz = message["mz"]
+    # All zones kept, cut value updated on each zone.
+    assert [zone["id"] for zone in mz["s"]] == [1, 2]
+    assert all(zone["cfg"]["cut"] == {"ob": 1, "bd": 150} for zone in mz["s"])
+    # Zone topology preserved unchanged (this is what an empty 'p' would clear).
+    assert mz["p"] == [{"z1": 1, "z2": 2, "t1": "BEACON-1", "t2": "BEACON-2"}]
+    # The cached config must not be mutated in place.
+    cached = cloud.get_mower("SERIAL-1")["last_status"]["payload"]["cfg"]["mz"]
+    assert cached["s"][0]["cfg"]["cut"] == {"ob": 1, "bd": 100}
+
+
 def test_dedicated_border_cut_setting_helpers_publish_single_setting() -> None:
     """Dedicated border-cut helpers should publish one setting at a time."""
     cloud = WorxCloud("user@example.com", "secret", "worx")


### PR DESCRIPTION
## Description
Border-cut on Vision (protocol 1) mowers is a **per-zone** setting (`cfg.mz.s[*].cfg.cut`), and the zone topology lives separately in `cfg.mz.p`. The previous `mz` form sent a single hard-coded zone with an empty `p`, which the mower interprets as "these are all the zones" → it drops the other zones and the beacon mapping (MTrab/landroid_cloud#1289). #390 worked around that by sending the top-level `{"cut":...}` form, but Vision models silently ignore it, so border-cut no longer applies.

This builds the command from the mower's cached `cfg.mz` (read-modify-write): it changes only the `cut` values and keeps `s` (all zones) and `p` (topology) intact. When no multizone config is cached it falls back to the top-level `{"cut":...}` form, so existing behaviour is unchanged.

## Test strategy
- `ruff format` / `ruff check` — clean
- `pytest tests/test_api_lifecycle.py` — 65 passed
- Existing border-cut tests stay green (their mocks have no `cfg.mz` → fallback path)
- New test `test_border_cut_settings_preserves_zones_via_mz`: with a cached two-zone `cfg.mz`, asserts the published payload is `{"mz":...}` with both zones present, `p` unchanged, only `cut` updated, and the cache not mutated in place
- **Validated on physical hardware** (WR206E Vision, 2 zones): border-cut applied, both zones and beacon topology preserved (confirmed in the Worx app). Counter-test with the old `p:[]` payload reproduced the zone deletion; re-sending the original `mz` restored both zones.

## Open question
The service has no zone parameter, so this applies the same `ob`/`bd` to **all** zones. Is that the intended behaviour, or should it target only the active zone? Happy to adjust.

## Known limitations
No change for non-multizone devices (fallback path). The local `cfg.mz` cache is not mirrored after sending; it is corrected by the next mower status.

## Required configuration changes
None.

## Semver
patch

Refs MTrab/landroid_cloud#1289, MTrab/landroid_cloud#876
