### PR TITLE
Decode GPS position from dat.rtk.pos for Vision/RTK mowers

### DIFF
--- a/pyworxcloud/utils/devices.py
+++ b/pyworxcloud/utils/devices.py
@@ -322,12 +322,28 @@ class DeviceHandler(LDict):
         if "dmp" in dat_payload:
             self.orientation = Orientation(dat_payload["dmp"])
 
+        gps_set = False
         modules = dat_payload.get("modules")
         if isinstance(modules, dict):
             if "4G" in modules:
                 gps = modules["4G"].get("gps")
                 if isinstance(gps, dict) and "coo" in gps:
                     self.gps = Location(gps["coo"][0], gps["coo"][1])
+                    gps_set = True
+
+        # GPS-equipped Vision/RTK mowers report their position under
+        # dat.rtk.pos = [latitude, longitude] instead of the legacy
+        # modules.4G.gps.coo schema, so fall back to that when present.
+        if not gps_set:
+            rtk = dat_payload.get("rtk")
+            if isinstance(rtk, dict):
+                pos = rtk.get("pos")
+                if (
+                    isinstance(pos, (list, tuple))
+                    and len(pos) >= 2
+                    and all(isinstance(coord, (int, float)) for coord in pos[:2])
+                ):
+                    self.gps = Location(pos[0], pos[1])
 
         rain = dat_payload.get("rain")
         if isinstance(rain, dict):


### PR DESCRIPTION
## Problem

GPS-equipped **Vision / RTK** mowers report their position to the cloud, but `self.gps` is never populated for them, so downstream consumers (e.g. the Home Assistant integration's `device_tracker`) get no coordinates.

## Root cause

`DeviceHandler._map_dat()` only reads GPS from the legacy `modules["4G"]["gps"]["coo"]` schema. RTK models instead report their fix under **`dat.rtk.pos` = `[latitude, longitude]`** (provider e.g. `positec.*`) and expose `HL`/`NL` modules rather than `4G`, so the existing branch never matches.

## Fix

When no `4G` GPS module sets coordinates, fall back to `dat.rtk.pos` and populate `self.gps = Location(lat, lon)`. Mutually exclusive in practice (a mower reports one schema or the other), and the legacy path keeps priority. No API surface change — existing `device.gps` consumers just start working for RTK mowers.

## Testing

Verified live on a **Landroid Vision Cloud400 (WR304E)**, fw `3.46.0+22`:
- raw `commandOut` payload contains `dat.rtk.pos = [56.41…, 10.88…]`, updating ~every 20s while mowing
- with the patch, `device.gps` is populated and the HA integration's `device_tracker` reports `source_type: gps` with correct, moving coordinates

This supersedes MTrab/landroid_cloud#1313 (moved here per maintainer request — fixing it in the library so the integration needs no change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)